### PR TITLE
Add Grails 7.0.0-RC2 release announcement post

### DIFF
--- a/posts/2025-09-11-grails-7-rc2.md
+++ b/posts/2025-09-11-grails-7-rc2.md
@@ -1,0 +1,317 @@
+---
+version: 7.0.0-RC2
+priorVersion: 7.0.0-RC1
+title: Apache Grails (Incubating) [%version] - Release Announcement
+date: September 11, 2025
+description: The Apache Grails (incubating) community is excited to announce the Milestone [%version] release of the Grails Framework!
+author: James Fredley
+image: grails-blog-index-3.png
+
+---
+
+# [%title]
+
+[%author]
+
+[%date]
+
+[%description] \
+We encourage you to try this pre-release version and provide your feedback [here](https://github.com/apache/grails-core/issues).
+
+## Download Source Code and Binary Distributions
+
+[Apache Grails Downloads](/download.html)
+
+## What's Changed
+For changes made in Grails 7 prior to [%version], check out the following blog posts: 
+* [Grails 7.0.0-M1](/blog/2024-12-23-grails-7-m1.html)
+* [Grails 7.0.0-M3](/blog/2025-03-05-grails-7-m3.html)
+* [Grails 7.0.0-M4](/blog/2025-06-10-grails-7-m4.html)
+* [Grails 7.0.0-M5](/blog/2025-07-15-grails-7-m5.html)
+* [Grails 7.0.0-RC1](/blog/2025-08-10-grails-7-rc1.html)
+
+### [%version] Changes:
+
+- Remove grails-forge unused docs generation and config @jamesfredley (#15041)
+- Update to Asset Pipeline 5.0.16 @jdaugherty (#15040)
+- Formatting helpers @matrei (#15034)
+- Remove deprecation warning for dot notation access @jamesfredley (#15035)
+- Add detailed documentation for standard Grails application profiles @jamesfredley (#15018)
+- Bump com.gradle.common-custom-user-data-gradle-plugin from 2.2.1 to 2.3 @[dependabot[bot]](https://github.com/apps/dependabot) (#14788)
+- Add profile support for Gradle dependency variants @jamesfredley (#15013)
+- Reformat code @matrei (#14925)
+- Update Feature info and Gradle templates @matrei (#14994)
+- Hide servlet features, should be selected via --servlet instead @jamesfredley (#15005)
+- Bump `spring-boot` and `byte-buddy` versions @matrei (#15006)
+- Update documentation and links to new GitHub and docs URLs @jamesfredley (#15003)
+- Remove embedded-mongodb feature and references @jamesfredley (#15004)
+- Remove grails-forge documentation guide @jamesfredley (#15000)
+- Cleanup broken documentation links, update links which have changed, standardize link syntax @jamesfredley (#14988)
+- Remove springloaded forge feature, it only works with JDK 8 or less @jamesfredley (#14992)
+- Make reloading feature switch between options @jamesfredley (#14985)
+- Update quartz and web console versions @jamesfredley (#14981)
+- Update links in docs to new internal link or updated external link @jamesfredley (#14973)
+- Add development reloading subsection to getting started section @jamesfredley (#14969)
+- fix: remove ServletContext from generated and test BootStrap.groovy files @jamesfredley (#14970)
+- Adjust core plugins artifactids in GrailsCompilerAutoConfiguration.java @jamesfredley (#14968)
+- Merge 7.0.0-RC1 tag @jamesfredley (#14964)
+
+## 🚀 Features
+
+- feature - #14017 - add back Micronaut support to Grails 7 with optional plugin @jdaugherty (#14953)
+
+## 🐛 Bug Fixes
+
+- Restart Geb VNC Container for each Test in a Spec to get correct recordings @JonasPammer (#14995)
+- Forge fixes @matrei (#15019)
+- grails-wrapper: Fix ClosureCompleter initialization in GradleCommand @jamesfredley (#15017)
+- Add `.git-blame-ignore-revs` @matrei (#15015)
+- fix: add asset-pipeline-bom to grails bom @jdaugherty (#14999)
+- fix: sitemesh3 rendering @jdaugherty (#14989)
+- Fix Typo dataStore not dataSource @lynchie14 (#14966)
+- fix: #14951 - make groovy extension merge for shadowJar reproducible @jdaugherty (#14952)
+- Issues-14899 fixes Documentation: Cleanup missing files @dauer (#14950)
+- fix: #14947 - class cast exception due to not using local variable @jdaugherty (#14960)
+
+## 🔧 Maintenance
+
+- Explicitly type render(object) to help IntelliJ ambiguous method overloading @jdaugherty (#15031)
+- refactor(grails-geb): Read GebConfig.groovy to allow overriding RemoteWebDriver @JonasPammer (#14987)
+- chore: conform to code style @matrei (#15033)
+- Enforce code style @matrei (#15016)
+- Include sources from composite builds in Groovydoc @jamesfredley (#15012)
+- ci: use `grails-forge` as base dir for dependabot @matrei (#15028)
+- chore(deps): bump com.gradle.common-custom-user-data-gradle-plugin from 2.2.1 to 2.3 in /grails-forge @[dependabot[bot]](https://github.com/apps/dependabot) (#15026)
+- chore(deps): bump com.gradle.develocity from 4.0.1 to 4.1.1 in /grails-forge @[dependabot[bot]](https://github.com/apps/dependabot) (#15025)
+- ci: add `grails-forge` dir to dependabot.yml @matrei (#15024)
+- chore(deps): bump com.gradle.develocity from 4.0.1 to 4.1.1 @[dependabot[bot]](https://github.com/apps/dependabot) (#15022)
+- Add `.git-blame-ignore-revs` @matrei (#15015)
+- Remove grails-publish plugin from build plugins @jamesfredley (#15014)
+- Forge publish - Add workaround so that release builds do not require signing credentials @jdaugherty (#14998)
+- Ensure Gradle Settings file & buildSrc/build.gradle are generated during the build Phase @jamesfredley (#14971)
+- chore: add versioning section to RELEASE.md and a link in README.md  @cbmarcum (#14962)
+- fix: #14951 - make groovy extension merge for shadowJar reproducible @jdaugherty (#14952)
+- chore: move grails-publish gradle plugin to its own project @jdaugherty (#14937)
+- chore: correct wording for the voting window @matrei (#14954)
+
+Full Changelog: [v[%priorVersion]...v[%version]](https://github.com/apache/grails-core/compare/v[%priorVersion]...v[%version])
+
+Upgrade instructions are available in the [documentation](https://docs.grails.org/[%version]/guide/upgrading.html#upgrading60x). 
+
+
+## Additional Releases
+
+The following plugins and tools are being released alongside Grails 7.0.0-RC2:
+
+### Grails Spring Security 7.0.0-RC2
+
+See the release page: [https://github.com/apache/grails-spring-security/releases/tag/v7.0.0-RC2](https://github.com/apache/grails-spring-security/releases/tag/v7.0.0-RC2)
+
+### Grails Quartz 4.0.0-RC2
+
+See the release page: [https://github.com/apache/grails-quartz/releases/tag/v4.0.0-RC2](https://github.com/apache/grails-quartz/releases/tag/v4.0.0-RC2)
+
+### Grails Redis 5.0.0-RC2
+
+See the release page: [https://github.com/apache/grails-redis/releases/tag/v5.0.0-RC2](https://github.com/apache/grails-redis/releases/tag/v5.0.0-RC2)
+
+### Grails GitHub Actions 1.0.0
+
+See the release page: [https://github.com/apache/grails-github-actions/releases/tag/v1.0.0](https://github.com/apache/grails-github-actions/releases/tag/v1.0.0)
+
+* Initial release of actions for Gradle projects' release workflows.
+
+**Purpose**  
+The actions being released are used in gradle projects for their release workflows to handle automated version management & documentation publishing.
+
+**Actions**
+* deploy-github-pages action - a GitHub Action to copy documentation files to a specified documentation branch. Works by creating a subfolder named the same as the documentation branch, checking out the documentation branch to that folder, staging files, and then pushing them. Action is configured via environment variables.
+* export-gradle-properties action - a GitHub Action that takes a Java properties file (typically gradle.properties) and exports each property as an environment variable for use in subsequent steps of your workflow.
+* post-release action - a GitHub Action that handles steps necessary to close out a GitHub Release process. Including incrementing the next version & merging back to the target branch
+* pre-release - a GitHub action that handles any pre-release steps as part of a GitHub release process. Including the project version being set based on the specified GitHub tag and updating the associated tag to the release.
+
+### Grails Gradle Publish 0.0.1
+
+See the release page: [https://github.com/apache/incubator-grails-gradle-publish/releases/tag/v0.0.1](https://github.com/apache/incubator-grails-gradle-publish/releases/tag/v0.0.1)
+
+## Dependency Upgrades
+In this release, we've upgraded several dependency versions, including but not limited to the following:
+
+* Asset Pipeline 5.0.16 (now cloud.wondrify.asset-pipeline)
+* Groovy 4.0.28
+* Spring Framework 6.2.10
+* Spring Boot 3.5.5
+* Gradle 8.14.3
+* See all in the [grails-bom](https://docs.grails.org/[%version]/ref/Versions/Grails%20BOM.html).
+
+## Generating a new Grails [%version] application with Grails Forge
+Try out Grails today by visiting our online application generator [Grails Forge](https://start.grails.org). This is the quickest and the recommended way to get started with Grails.
+
+After installing JetBrains' IntelliJ IDEA 2025.2 or later and the [Grails Plugin](https://plugins.jetbrains.com/plugin/18504-grails), the Grails Application Forge will also be available under New Project in IntelliJ IDEA. 
+
+Within your newly generated project you can access the Grails CLIs with the Grails Wrapper.
+
+See the [Types of CLI](https://docs.grails.org/[%version]/guide/gettingStarted.html#_types_of_command_line_interface_cli) section in the documentation for details on each CLI.
+
+grail-shell-cli
+
+```shell
+grailsw
+```
+
+grails-forge-cli
+
+```shell
+grailsw -t forge
+```
+
+## Installing Grails CLIs [%version] with SDKMan
+Alternatively, you can quickly install Grails [%version] CLIs (grails-shell-cli and grails-forge-cli) using [SDKMan](https://sdkman.io).
+
+See the [Types of CLI](https://docs.grails.org/[%version]/guide/gettingStarted.html#_types_of_command_line_interface_cli) section in the documentation for details on each CLI.
+
+1. If you don't have SDKMan installed, follow the instructions at [SDKMan Installation Guide](https://sdkman.io/install) to set it up.
+2. Once SDKMan is installed, open your terminal and run the following command to install Grails [%version]:
+
+    ```shell
+    sdk install grails [%version]
+    ```
+
+3. You're all set! To verify the installation, run:
+
+    ```shell
+    grails --version
+    ```
+
+The Grails Shell CLI can be accessed as:
+
+```shell
+grails
+``` 
+or
+```shell
+grails-shell-cli
+```
+The Grails Forge CLI can be accessed as:
+```shell
+grails -t forge
+```
+or
+```shell
+grails-forge-cli
+```    
+
+## Upgrading Your Existing Applications to Grails [%version]
+If you already have a Grails application and want to upgrade to the latest version, follow these steps:
+
+1. Open the project in your favorite IDE (preferably JetBrains' IntelliJ IDEA 2025.2 or later).
+2. Update your application's `gradle.properties` file to specify Grails [%version] as the desired version.
+
+    ```properties
+    grailsVersion=[%version]
+    ```
+
+3. Make any necessary adjustments to your application code, configuration, and dependencies to ensure compatibility with
+   the new version. [See Upgrade Guide](https://docs.grails.org/[%version]/guide/upgrading.html#upgrading60x)
+
+Normally, Grails Core dependencies are automatically updated using the Grails Bill of Materials (BOM). However, if you
+have specific versions defined in your build configuration, you may need to manually update them to align with
+Grails [%version].
+
+By following these steps, you should be able to transition your existing Grails application to Grails [%version].
+
+### Exploring Alternative Approaches
+If manual dependency updates seem daunting, or you want a more streamlined approach, consider the following alternatives:
+
+#### 1. Use Grails Forge Website
+Visit [Grails Forge](https://start.grails.org) and generate a new Grails application with Grails [%version]. Compare the
+versions in the newly generated application with your existing one to identify any discrepancies. This can serve as a
+reference point for your update.
+
+#### 2. Automated Dependency Update Bots
+Configure automated dependency update bots like [Renovate](https://docs.renovatebot.com) or
+[Dependabot](https://dependabot.com) with your source control platform (e.g., GitHub). These bots can automatically
+detect and update outdated dependencies in your project, including Grails dependencies, saving you time and effort in
+manual updates.
+
+With these steps and alternative approaches, you should be well on your way to enjoying the exciting features and
+improvements in Grails [%version].
+
+## Why should you try out Grails [%version]?
+* Help us test this major upgrade of the Grails Framework and provide feedback.
+* Be ready for when Grails 7 is released.
+
+## Grails 7 Release Schedule
+* We will continue to work on [updating and fixing issues](https://github.com/orgs/apache/projects/487/views/2) over the next few
+  weeks.
+* Based on feedback, an Apache Grails RC or Final release is targeted for September 2025.
+
+## Apache Grails Mailing Lists
+### Users Mailing List
+The users mailing list will be a General purpose list for questions and discussion about Grails.\
+**Web Archive:** [https://lists.apache.org/list.html?users@grails.apache.org](https://lists.apache.org/list.html?users@grails.apache.org) \
+**Subscribe:** Send a blank email to [users-subscribe@grails.apache.org](mailto:users-subscribe@grails.apache.org)
+
+### Dev Mailing List
+The dev mailing list is focused on the framework implementation and its evolution. \
+**Web Archive:** [https://lists.apache.org/list.html?dev@grails.apache.org](https://lists.apache.org/list.html?dev@grails.apache.org) \
+**Subscribe:** Send a blank email to [dev-subscribe@grails.apache.org](mailto:dev-subscribe@grails.apache.org)
+
+When participating in mailing lists, you should never include any personally identifiable information (PII) like
+your address, phone number or email address, as all messages sent to these lists are publicly accessible and archived,
+meaning anyone can view your information. Make sure your email client does not add your signature with these items.
+
+## Thank you!
+A huge thank you to our amazing community for supporting the Grails Framework over the past 20 years! We’re excited for
+the future and grateful for the opportunity to continue innovating and pushing Grails forward together.
+
+## Contributors
+We would like to extend our heartfelt thanks to all the contributors who made Grails [%version] possible. \
+Special thanks to:
+
+* [James Daugherty](https://github.com/jdaugherty)
+* [James Fredley](https://github.com/jamesfredley)
+* [Mattias Reichel](https://github.com/matrei)
+* [Scott Murphy](https://github.com/codeconsole)
+* [Brian Koehmstedt](https://github.com/bkoehm)
+* [Søren Berg Glasius](https://github.com/sbglasius)
+* [Paul King](https://github.com/paulk-asert)
+* [Jonas Pammer](https://github.com/JonasPammer)
+* [Gianluca Sartori](https://github.com/gsartori)
+* [David Estes](https://github.com/davydotcom)
+* [Michael Yan](https://github.com/rainboyan)
+* [Jude Vargas](https://github.com/JudeRV)
+* [Thomas Rasmussen](https://github.com/dauer)
+* [Laura Estremera](https://github.com/irllyliketoast)
+* [Hallie Uczen](https://github.com/shadowchaser000)
+* [Jérôme Prinet](https://github.com/jprinet)
+* [Stephen Lynch](https://github.com/lynchie14)
+* [Andrew Herring](https://github.com/dreewh)
+* [Yasuharu Nakano](https://github.com/nobeans)
+* [Aaron Mondelblatt](https://github.com/amondel2)
+* [Arjang Chinichian](https://github.com/arjangch)
+* [Felix Scheinost](https://github.com/felixscheinost)
+* [Carl Marcum](https://github.com/cbmarcum)
+* [Eugene Kamenev](https://github.com/eugene-kamenev)
+* [yucai](https://github.com/huangyucaigit)
+* [gandharvas](https://github.com/gandharvas)
+* [zyro](https://github.com/zyro23)
+
+Recent Contributors by Project:
+
+* [grails-core](https://github.com/apache/grails-core/graphs/contributors[%6MonthsBackForGitHub])
+* [grails-spring-security](https://github.com/apache/grails-spring-security/graphs/contributors[%6MonthsBackForGitHub])
+* [grails-static-website](https://github.com/apache/grails-static-website/graphs/contributors[%6MonthsBackForGitHub])
+* [grails-forge-ui](https://github.com/apache/grails-forge-ui/graphs/contributors[%6MonthsBackForGitHub])
+* [grails-quartz](https://github.com/apache/grails-quartz/graphs/contributors[%6MonthsBackForGitHub])
+* [grails-gradle-publish](https://github.com/apache/incubator-grails-gradle-publish/graphs/contributors[%6MonthsBackForGitHub])
+* [grails-redis](https://github.com/apache/grails-redis/graphs/contributors[%6MonthsBackForGitHub])
+* [grails-github-actions](https://github.com/apache/grails-github-actions/graphs/contributors[%6MonthsBackForGitHub])
+
+[Combined Commit List](https://github.com/search?q=repo%3Aapache%2Fgrails-core+repo%3Aapache%2Fgrails-spring-security+repo%3Aapache%2Fgrails-static-website+repo%3Aapache%2Fgrails-forge-ui+repo%3Aapache%2Fgrails-quartz+repo%3Aapache%2Fincubator-grails-gradle-publish+repo%3Agrails-redis+repo%3Agrails-github-actions+is%3Apublic&type=commits&s=committer-date&o=desc)
+
+Their dedication and hard work have significantly contributed to the release of Grails [%version].
+
+Join the [Grails Slack Community](https://grails.slack.com), share your feedback, and contribute to making Grails Framework even better in
+the future. Happy coding!
+


### PR DESCRIPTION
Introduces a new blog post announcing the release of Apache Grails 7.0.0-RC2. The post details new features, bug fixes, dependency upgrades, related plugin releases, upgrade instructions, and contributor acknowledgments.