### PR TITLE
Replace blocked surefire-report action in Java CI

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -32,7 +32,6 @@ jobs:
           (set -x; ./gradlew clean check --no-daemon)
       - name: Publish Test Report
         if: failure()
-        uses: scacap/action-surefire-report@3dacff26879cd2a7f2160d101254032a3707fe6f # v1.12.0
+        uses: mikepenz/action-junit-report@d9f48fc87bc235f7e214acf696ca5abc0a986f16 # v6.4.2
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
           report_paths: '**/build/test-results/test/TEST-*.xml'


### PR DESCRIPTION
## Summary

Java CI dies at startup on `apache/grails-static-website` because `scacap/action-surefire-report` is not on the ASF GitHub Actions allowlist.

Example: https://github.com/apache/grails-static-website/actions/runs/32297211217

Replace that failure-report step with `mikepenz/action-junit-report@v6.4.2`, which is allowlisted (`mikepenz/action-junit-report@*` in [approved_patterns.yml](https://github.com/apache/infrastructure-actions/blob/main/approved_patterns.yml)). SHA-pinned to match the rest of the workflows.

No other `uses:` in this repo is blocked. `actions/*` is auto-allowed; `gradle/actions/setup-gradle@50e97c2...` already matches an allowlisted SHA.

## Test plan

- [ ] Confirm Java CI starts (no "action not allowed" startup failure)
- [ ] On a red `check` run, confirm the JUnit report step can publish
