### PR TITLE
Add Grails 8 command-objects-and-forms guide.

### DIFF
--- a/buildSrc/src/main/groovy/website/gradle/RenderGuidesPlugin.groovy
+++ b/buildSrc/src/main/groovy/website/gradle/RenderGuidesPlugin.groovy
@@ -370,7 +370,8 @@ class RenderGuidesPlugin {
      *
      * <p>Supports the four attribute styles that account for 100% of usage
      * across the vendored guides ({@code []}, {@code [indent=N]},
-     * {@code [tag(s)=foo,bar]}, {@code [lines=N..M[,P..Q]]}).</p>
+     * {@code [tag(s)=foo;bar]} (commas also accepted),
+     * {@code [lines=N..M[,P..Q]]}).</p>
      *
      * <p>Three include shapes are recognised:</p>
      * <ul>
@@ -510,7 +511,9 @@ class RenderGuidesPlugin {
      */
     @CompileDynamic
     static String extractTaggedRegions(String body, String tagSpec) {
-        List<String> tokens = tagSpec.split(',').collect { it.trim() }.findAll { it }
+        // Asciidoctor's documented multi-tag separator is `;`. Historical
+        // guides also use commas (`tags=foo,bar`), so accept both.
+        List<String> tokens = tagSpec.split(/[,;]/).collect { it.trim() }.findAll { it }
         Set<String> includeTags = tokens.findAll { !it.startsWith('!') } as Set
         Set<String> excludeTags = tokens.findAll { it.startsWith('!') }.collect { it.substring(1) } as Set
         boolean wildcardAll = includeTags.contains('*') || includeTags.contains('**')

--- a/buildSrc/src/test/groovy/website/gradle/RenderGuidesPluginSnippetSpec.groovy
+++ b/buildSrc/src/test/groovy/website/gradle/RenderGuidesPluginSnippetSpec.groovy
@@ -1,0 +1,74 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package website.gradle
+
+import spock.lang.Specification
+
+class RenderGuidesPluginSnippetSpec extends Specification {
+
+    private static final String CONTROLLER = '''\
+        //tag::save-full[]
+        //tag::save[]
+        def save(Player player) {
+            //end::save[]
+            //tag::save-handleErrors[]
+            if (player.hasErrors()) {
+                return
+            }
+            //end::save-handleErrors[]
+            player.save flush: true
+            //tag::save[]
+        }
+        //end::save[]
+        //end::save-full[]
+
+        //tag::playerInfo[]
+        class PlayerInfo {
+            String name
+        //end::playerInfo[]
+            //tag::playerInfo-constraints[]
+            static constraints = {
+                name blank: false
+            }
+            //end::playerInfo-constraints[]
+        //tag::playerInfo[]
+        }
+        //end::playerInfo[]
+        '''.stripIndent()
+
+    def 'semicolon-separated tags concatenate in document order'() {
+        when:
+        String save = RenderGuidesPlugin.extractTaggedRegions(CONTROLLER, 'save;save-handleErrors')
+        String playerInfo = RenderGuidesPlugin.extractTaggedRegions(CONTROLLER, 'playerInfo;playerInfo-constraints')
+
+        then:
+        save.contains('def save(Player player) {')
+        save.contains('if (player.hasErrors()) {')
+        !save.contains('player.save flush: true')
+        playerInfo.contains('class PlayerInfo {')
+        playerInfo.contains('static constraints = {')
+        playerInfo.contains('name blank: false')
+    }
+
+    def 'comma-separated tags still concatenate'() {
+        expect:
+        RenderGuidesPlugin.extractTaggedRegions(CONTROLLER, 'save,save-handleErrors')
+                .contains('if (player.hasErrors()) {')
+    }
+}

--- a/conf/guides.yml
+++ b/conf/guides.yml
@@ -449,6 +449,7 @@ guides:
     subtitle: 'This guide will explain how you can use command objects to validate input data in a Grails application'
     authors:
       - 'Matthew Moss'
+      - 'Sanjana'
     category: 'Grails Apprentice'
     publicationDate: '2017-01-09'
     versions:
@@ -519,7 +520,39 @@ guides:
           runningTheApp:
             title: Running the Application
           helpWithGrails:
-            title: Do you need help with Grails?  
+            title: Do you need help with Grails?
+      '8':
+        sourcePath: guides/command-objects-and-forms/v8
+        publicationDate: '2026-08-26'
+        tags:
+          - 'command-objects'
+          - 'forms'
+          - 'data-binding'
+          - 'validation'
+          - 'controllers'
+          - 'gsp'
+          - 'web-layer'
+          - 'unit-tests'
+          - 'functional-tests'
+          - 'beginner'
+        sampleRef:
+          repo: 'grails-guides/command-objects-and-forms'
+          branch: 'grails8'
+        toc:
+          gettingStarted:
+            title: Getting Started
+            requirements: What you will need
+            howto: How to complete the guide
+          whatAreCommandObjects: What are command objects?
+          writingTheApp:
+            title: Writing the Application
+            createTheController: Create the controller
+            addCreateAndSaveActions: Implement the create and save actions
+            addEditAndUpdateActions: Implement the edit and update actions
+          runningTheApp:
+            title: Running the Application
+          helpWithGrails:
+            title: Do you need help with Grails?
 
   - name: 'creating-your-first-grails-app'
     title: 'Creating your first Grails Application'

--- a/guides/command-objects-and-forms/v8/guide/addCreateAndSaveActions.adoc
+++ b/guides/command-objects-and-forms/v8/guide/addCreateAndSaveActions.adoc
@@ -1,5 +1,5 @@
-Add a `create` action. The `Player` instance here is *not* a command object because it
-is not an action parameter:
+Next, add the ability to create new players. To `PlayerController`, add the `create`
+action.
 
 [source,groovy]
 .grails-app/controllers/demo/PlayerController.groovy
@@ -7,9 +7,43 @@ is not an action parameter:
 include::../snippets/grails-app/controllers/demo/PlayerController.groovy[tags=create, indent=0]
 ----
 
-From http://localhost:8080/player/index, open *New Player*. Submitting the form needs a
-`save` action. When `Player` is an action argument, it *is* a command object: Grails binds
-request data, injects dependencies where needed, and validates.
+While this action does make use of the `Player` class, the instance of `Player` *is not* a command object
+since it is not an argument to the action. That should make sense: the intent is to render an empty
+form, so there is no submitted input to bind yet.
+
+From the Player List (http://localhost:8080/player/index), click *New Player* to see the create form
+(http://localhost:8080/player/create). If you fill in the form and click *Create* now, you get a
+`404 Page Not Found` error, because `save` is not defined yet. Add that next.
+
+[source,groovy]
+----
+    def save(Player player) {
+        // ...
+    }
+----
+
+Here, `player` *is* a command object, because it is an argument to the action. Behind
+the scenes, Grails rewrites the action to fetch existing records (if necessary), bind input
+data to the command object, perform dependency injection, and validate the object.
+
+The best feature here is https://grails.apache.org/docs/latest/guide/theWebLayer.html#dataBinding[data binding].
+The create view is already in `initial/`. Grails 8 scaffolding uses the Fields plugin: `f:all`
+renders an input for every `Player` property.
+
+[source,html]
+.grails-app/views/player/create.gsp
+----
+<g:form action="save">
+    <fieldset class="form">
+        <f:all bean="player"/>
+    </fieldset>
+    <fieldset class="buttons">
+        <g:submitButton name="create" class="save" value="${message(code: 'default.button.create.label', default: 'Create')}" />
+    </fieldset>
+</g:form>
+----
+
+The generated input `name` attributes match the properties of the domain class `Player`.
 
 [source,groovy]
 .grails-app/domain/demo/Player.groovy
@@ -17,10 +51,75 @@ request data, injects dependencies where needed, and validates.
 include::../snippets/grails-app/domain/demo/Player.groovy[]
 ----
 
-Form field names match `Player` properties, so binding fills `name`, `game`, `region`,
-and converts `wins` / `losses` to `int`. Domain `constraints` run automatically.
+Data binding takes the form-submitted string values for `name`, `game`, and `region`
+(if set) and sets those properties on the command object `player`. The submitted
+strings for `wins` and `losses` are converted to `int`. The convention of using the same
+names for domain properties and input fields is what keeps this code small: view fields
+are pre-filled from domain objects, and command objects are filled from submitted form data.
 
-Complete `save` with error handling and persistence:
+After binding, domain `constraints` run. That is the place to add error handling. The
+`HttpStatus` import is already at the top of the controller from the `index` / `show` step.
+Update the `save` action:
+
+[source,groovy]
+.grails-app/controllers/demo/PlayerController.groovy
+----
+include::../snippets/grails-app/controllers/demo/PlayerController.groovy[tags=save;save-handleErrors, indent=0]
+----
+
+The generated GSPs do as much client-side checking as they can. To see server-side
+validation, use `curl` while the app is running. The create form posts
+`application/x-www-form-urlencoded` (not multipart), so match that:
+
+[source,bash]
+----
+curl --request POST \
+  --header "Accept: application/json" \
+  --header "Content-Type: application/x-www-form-urlencoded" \
+  --data "name=Bob+Smith&wins=42&losses=abc" \
+  "http://localhost:8080/player/save.json"
+----
+
+You should receive HTTP `422 Unprocessable Entity` with a type-mismatch on `losses`
+(displayed nicely here):
+
+[source,json]
+----
+{"errors": [
+  {"object": "demo.Player",
+   "field": "losses",
+   "rejected-value": "abc",
+   "message": "Property losses is type-mismatched"}
+]}
+----
+
+Grails 8 reports the type-mismatch for this request. `game` is also required (`blank: false`),
+but a conversion error on another field is what this particular payload surfaces.
+
+We are going to verify this with a functional test.
+
+include::{commondir}/common-functionalTestsIntro.adoc[]
+
+The companion uses JDK `java.net.http.HttpClient` (no extra HTTP-client dependency). Successful
+form posts follow `request.withFormat` and *redirect*, so the spec disables automatic redirect
+following and then GETs the JSON show representation.
+
+[source,groovy]
+.src/integration-test/groovy/demo/PlayerControllerFuncSpec.groovy
+----
+include::../snippets/src/integration-test/groovy/demo/PlayerControllerFuncSpec.groovy[tags=saveSpec]
+----
+
+<1> `serverPort` is injected. It is the random port where the application runs during the functional test.
+<2> If your client accepts JSON, set the `Accept` header.
+<3> This POST is form-urlencoded, the same `Content-Type` as the create form. Set it explicitly.
+<4> Failed command-object validation returns `422 Unprocessable Entity`.
+
+This first-stage spec is enough to run `./gradlew integrationTest` after `save` exists.
+The next chapter adds a second test for mass-assignment protection.
+
+Now that binding, validation, and error-checking are in place, complete `save` so it persists
+the player and responds to the form:
 
 [source,groovy]
 .grails-app/controllers/demo/PlayerController.groovy
@@ -28,33 +127,12 @@ Complete `save` with error handling and persistence:
 include::../snippets/grails-app/controllers/demo/PlayerController.groovy[tags=save-full, indent=0]
 ----
 
-To see server-side validation (the GSPs already do client-side checks), with the app
-running:
-
-[source,bash]
-----
-curl --request POST \
-  --header "Accept: application/json" \
-  --form "name=Bob Smith" --form "wins=42" --form "losses=abc" \
-  "http://localhost:8080/player/save.json"
-----
-
-You should get HTTP `422` with errors for `losses` (type mismatch) and missing `game`.
-
-The companion includes a functional test that asserts the same behaviour with
-`java.net.http.HttpClient`:
-
-[source,groovy]
-.src/integration-test/groovy/demo/PlayerControllerFuncSpec.groovy
-----
-include::../snippets/src/integration-test/groovy/demo/PlayerControllerFuncSpec.groovy[]
-----
-
-<4> Failed command-object validation returns `422 Unprocessable Entity`.
+You should now be able to create and save new players.
 
 [NOTE]
 ====
-Controller code here stays small on purpose. For a fuller starting point in your own apps:
+The example controller code here is kept small on purpose so the guide can focus on command
+objects. For a fuller starting point in your own apps:
 
 ----
 ./grailsw generate-controller demo.Player

--- a/guides/command-objects-and-forms/v8/guide/addCreateAndSaveActions.adoc
+++ b/guides/command-objects-and-forms/v8/guide/addCreateAndSaveActions.adoc
@@ -1,0 +1,62 @@
+Add a `create` action. The `Player` instance here is *not* a command object because it
+is not an action parameter:
+
+[source,groovy]
+.grails-app/controllers/demo/PlayerController.groovy
+----
+include::../snippets/grails-app/controllers/demo/PlayerController.groovy[tags=create, indent=0]
+----
+
+From http://localhost:8080/player/index, open *New Player*. Submitting the form needs a
+`save` action. When `Player` is an action argument, it *is* a command object: Grails binds
+request data, injects dependencies where needed, and validates.
+
+[source,groovy]
+.grails-app/domain/demo/Player.groovy
+----
+include::../snippets/grails-app/domain/demo/Player.groovy[]
+----
+
+Form field names match `Player` properties, so binding fills `name`, `game`, `region`,
+and converts `wins` / `losses` to `int`. Domain `constraints` run automatically.
+
+Complete `save` with error handling and persistence:
+
+[source,groovy]
+.grails-app/controllers/demo/PlayerController.groovy
+----
+include::../snippets/grails-app/controllers/demo/PlayerController.groovy[tags=save-full, indent=0]
+----
+
+To see server-side validation (the GSPs already do client-side checks), with the app
+running:
+
+[source,bash]
+----
+curl --request POST \
+  --header "Accept: application/json" \
+  --form "name=Bob Smith" --form "wins=42" --form "losses=abc" \
+  "http://localhost:8080/player/save.json"
+----
+
+You should get HTTP `422` with errors for `losses` (type mismatch) and missing `game`.
+
+The companion includes a functional test that asserts the same behaviour with
+`java.net.http.HttpClient`:
+
+[source,groovy]
+.src/integration-test/groovy/demo/PlayerControllerFuncSpec.groovy
+----
+include::../snippets/src/integration-test/groovy/demo/PlayerControllerFuncSpec.groovy[]
+----
+
+<4> Failed command-object validation returns `422 Unprocessable Entity`.
+
+[NOTE]
+====
+Controller code here stays small on purpose. For a fuller starting point in your own apps:
+
+----
+./grailsw generate-controller demo.Player
+----
+====

--- a/guides/command-objects-and-forms/v8/guide/addEditAndUpdateActions.adoc
+++ b/guides/command-objects-and-forms/v8/guide/addEditAndUpdateActions.adoc
@@ -1,0 +1,64 @@
+`edit` and `update` mirror `create` / `save`. With a `Player` command object, Grails loads
+the existing row for the form. The scaffolded `edit.gsp` already omits wins/losses fields,
+but that alone does not block a crafted request from changing them:
+
+[source,bash]
+----
+curl --request GET "http://localhost:8080/player/show/1.json"
+curl --request POST --form "id=1" --form "wins=2" --form "losses=194" \
+  "http://localhost:8080/player/update.json"
+----
+
+Use a dedicated command object that only exposes editable fields. Define `PlayerInfo` in
+the same file as the controller (Grails makes same-file command classes `Validateable`):
+
+[source,groovy]
+.grails-app/controllers/demo/PlayerController.groovy
+----
+include::../snippets/grails-app/controllers/demo/PlayerController.groovy[tags=playerInfo;playerInfo-constraints]
+----
+
+Wire `update` to that command object, copy allowed properties onto the domain instance,
+and validate the command object first:
+
+[source,groovy]
+.grails-app/controllers/demo/PlayerController.groovy
+----
+include::../snippets/grails-app/controllers/demo/PlayerController.groovy[tags=update, indent=0]
+----
+
+Because `PlayerInfo` has no `wins` / `losses`, those values are ignored even if posted.
+
+Unit tests in the companion cover the controller and constraints:
+
+[source,groovy]
+.src/test/groovy/demo/PlayerControllerSpec.groovy
+----
+include::../snippets/src/test/groovy/demo/PlayerControllerSpec.groovy[indent=0]
+----
+
+<1> Call `update()` with values in `params`; binding fills the command object as at runtime.
+
+[source,groovy]
+.src/test/groovy/demo/PlayerInfoSpec.groovy
+----
+include::../snippets/src/test/groovy/demo/PlayerInfoSpec.groovy[indent=0]
+----
+
+If you define the command class under `src/` instead of next to the controller, implement
+`grails.validation.Validateable` to keep a `constraints` block:
+
+[source,groovy]
+----
+class PlayerInfo implements grails.validation.Validateable {
+    String name
+    String game
+    String region
+
+    static constraints = {
+        name blank: false
+        game blank: false
+        region nullable: true
+    }
+}
+----

--- a/guides/command-objects-and-forms/v8/guide/addEditAndUpdateActions.adoc
+++ b/guides/command-objects-and-forms/v8/guide/addEditAndUpdateActions.adoc
@@ -84,8 +84,8 @@ curl --header "Accept: application/json" "http://localhost:8080/player/show/1.js
 ----
 
 After the POST, Alexis Barnett has two wins and 194 losses instead of 96 and 30. A form POST
-hits `request.withFormat`'s `form` branch and redirects; GET the show URL afterwards to see
-the stored values.
+hits the `form` branch of `request.withFormat` and redirects; GET the show URL afterwards to
+see the stored values.
 
 One way to fix this would be to stop using a `Player` command object and bind fields by hand.
 Command objects do not have to be domain classes, though: use any class. Define `PlayerInfo`
@@ -163,7 +163,7 @@ Create a unit test for that behaviour:
 [source,groovy]
 .src/test/groovy/demo/PlayerControllerSpec.groovy
 ----
-include::../snippets/src/test/groovy/demo/PlayerControllerSpec.groovy[indent=0]
+include::../snippets/src/test/groovy/demo/PlayerControllerSpec.groovy[tags=updateSpec, indent=0]
 ----
 
 <1> Call the no-argument `update()` and put values in `params`. Databinding fills the command
@@ -191,15 +191,28 @@ include::../snippets/src/test/groovy/demo/PlayerInfoSpec.groovy[indent=0]
 ----
 
 Revise `update` once more so command-object errors are checked *before* the domain instance
-is loaded and saved. `respond info.errors, view: 'edit'` returns the error payload for API
-clients. For an HTML form post it also re-renders `edit.gsp`, but with a `playerInfo` model
-rather than `player`, so the scaffold form does not redisplay those errors. This beginner
-sample does not add an error-model bridge:
+is loaded and saved. Copying onto `Player` still runs domain constraints, including
+`unique: true` on `name`, so inspect the `save` result and return those errors instead of
+reporting success. Because `update` is `@Transactional` and the `Player` is already dirty,
+call `transactionStatus.setRollbackOnly()` so the failed instance is not flushed when the
+action returns. `respond info.errors, view: 'edit'` returns the command-object error
+payload for API clients. For an HTML form post it also re-renders `edit.gsp`, but with a
+`playerInfo` model rather than `player`, so the scaffold form does not redisplay those
+errors. This beginner sample does not add an error-model bridge:
 
 [source,groovy]
 .grails-app/controllers/demo/PlayerController.groovy
 ----
 include::../snippets/grails-app/controllers/demo/PlayerController.groovy[tags=update, indent=0]
+----
+
+Add a unit test that a duplicate `name` is reported instead of treated as a successful
+update:
+
+[source,groovy]
+.src/test/groovy/demo/PlayerControllerSpec.groovy
+----
+include::../snippets/src/test/groovy/demo/PlayerControllerSpec.groovy[tags=uniqueSpec, indent=0]
 ----
 
 The companion functional spec's second test posts a crafted update after a real save and

--- a/guides/command-objects-and-forms/v8/guide/addEditAndUpdateActions.adoc
+++ b/guides/command-objects-and-forms/v8/guide/addEditAndUpdateActions.adoc
@@ -1,35 +1,164 @@
-`edit` and `update` mirror `create` / `save`. With a `Player` command object, Grails loads
-the existing row for the form. The scaffolded `edit.gsp` already omits wins/losses fields,
-but that alone does not block a crafted request from changing them:
+Next, add the ability to update existing players. Add `edit` and `update` actions
+to `PlayerController`. These look almost the same as `create` and `save`.
+
+[source,groovy]
+----
+    def edit(Player player) {
+        respond player
+    }
+
+    @Transactional
+    def update(Player player) {
+        if (player == null) {
+            render status: HttpStatus.NOT_FOUND
+            return
+        }
+
+        if (player.hasErrors()) {
+            respond player.errors, view: 'edit'
+            return
+        }
+
+        player.save flush: true
+
+        request.withFormat {
+            form multipartForm { redirect player }
+            '*' { respond player, status: HttpStatus.OK }
+        }
+    }
+----
+
+The `edit` action starts with a `Player` command object; Grails fetches the existing `Player`,
+and those properties are the initial values of the form in `edit.gsp`. The `update` action is
+the same as `save`, except that errors re-render `edit` rather than `create`, and the HTTP
+status for success is `OK` rather than `CREATED`.
+
+On the assumption that a player's win and loss counts are managed elsewhere, wins and losses
+have already been removed from `edit.gsp`. The Fields plugin is used with an explicit property
+list instead of `f:all`:
+
+[source,html]
+.grails-app/views/player/edit.gsp
+----
+<g:form resource="${this.player}" method="PUT">
+    <g:hiddenField name="version" value="${this.player?.version}" />
+    <fieldset class="form">
+        <f:field bean="player" property="name" />
+        <f:field bean="player" property="game" />
+        <f:field bean="player" property="region" />
+    </fieldset>
+    <fieldset class="buttons">
+        <input class="save" type="submit" value="${message(code: 'default.button.update.label', default: 'Update')}" />
+    </fieldset>
+</g:form>
+----
+
+While the application is running, open a player from the list. You can see the win/loss count
+on the show page, but *Edit* does not offer those fields.
+
+That is not sufficient. Removing inputs from the form *does not prevent* those fields from
+being changed. A crafted request can still submit them.
 
 [source,bash]
 ----
-curl --request GET "http://localhost:8080/player/show/1.json"
-curl --request POST --form "id=1" --form "wins=2" --form "losses=194" \
+curl --header "Accept: application/json" "http://localhost:8080/player/show/1.json"
+----
+
+[source,json]
+----
+{"id":1, "game":"Pandemic", "losses":30, "name":"Alexis Barnett", "region":"EAST", "wins":96}
+----
+
+[source,bash]
+----
+curl --request POST \
+  --header "Accept: application/json" \
+  --header "Content-Type: application/x-www-form-urlencoded" \
+  --data "id=1&wins=2&losses=194" \
   "http://localhost:8080/player/update.json"
 ----
 
-Use a dedicated command object that only exposes editable fields. Define `PlayerInfo` in
-the same file as the controller (Grails makes same-file command classes `Validateable`):
+[source,bash]
+----
+curl --header "Accept: application/json" "http://localhost:8080/player/show/1.json"
+----
+
+After the POST, Alexis Barnett has two wins and 194 losses instead of 96 and 30. A form POST
+hits `request.withFormat`'s `form` branch and redirects; GET the show URL afterwards to see
+the stored values.
+
+One way to fix this would be to stop using a `Player` command object and bind fields by hand.
+Command objects do not have to be domain classes, though: use any class. Define `PlayerInfo`
+in `PlayerController.groovy` below the controller. Its property names match the edit form's
+inputs, so only those fields bind.
 
 [source,groovy]
 .grails-app/controllers/demo/PlayerController.groovy
 ----
-include::../snippets/grails-app/controllers/demo/PlayerController.groovy[tags=playerInfo;playerInfo-constraints]
+include::../snippets/grails-app/controllers/demo/PlayerController.groovy[tags=playerInfo, indent=0]
 ----
 
-Wire `update` to that command object, copy allowed properties onto the domain instance,
-and validate the command object first:
+Change `update` to use `PlayerInfo` as the command object. Load the `Player`, then copy the
+command object's properties onto it:
 
 [source,groovy]
-.grails-app/controllers/demo/PlayerController.groovy
 ----
-include::../snippets/grails-app/controllers/demo/PlayerController.groovy[tags=update, indent=0]
+    @Transactional
+    def update(PlayerInfo info) {
+        Player player = Player.get(params.id)
+        if (player == null) {
+            render status: HttpStatus.NOT_FOUND
+            return
+        }
+
+        player.properties = info.properties
+        player.save flush: true
+
+        if (player.hasErrors()) {
+            respond player.errors, view: 'edit'
+            return
+        }
+
+        request.withFormat {
+            form multipartForm { redirect player }
+            '*' { respond player, status: HttpStatus.OK }
+        }
+    }
 ----
 
-Because `PlayerInfo` has no `wins` / `losses`, those values are ignored even if posted.
+Because `PlayerInfo` does *not* contain `wins` or `losses`, those values are ignored even if
+they are posted.
 
-Unit tests in the companion cover the controller and constraints:
+[source,bash]
+----
+curl --header "Accept: application/json" "http://localhost:8080/player/show/4.json"
+----
+
+[source,json]
+----
+{"id":4, "name":"Catherine Newton", "game":"Scythe", "region":"WEST", "wins":66, "losses":40}
+----
+
+[source,bash]
+----
+curl --request POST \
+  --header "Accept: application/json" \
+  --header "Content-Type: application/x-www-form-urlencoded" \
+  --data "id=4&name=June+Smith&game=Chess&region=NORTH&wins=0&losses=10" \
+  "http://localhost:8080/player/update.json"
+
+curl --header "Accept: application/json" "http://localhost:8080/player/show/4.json"
+----
+
+[source,json]
+----
+{"id":4, "name":"June Smith", "game":"Chess", "region":"NORTH", "wins":66, "losses":40}
+----
+
+`name`, `game`, and `region` updated; `wins` and `losses` did not. The `PlayerInfo` command
+object restricted which fields are accepted.
+
+Create a unit test for that behaviour:
 
 [source,groovy]
 .src/test/groovy/demo/PlayerControllerSpec.groovy
@@ -37,7 +166,23 @@ Unit tests in the companion cover the controller and constraints:
 include::../snippets/src/test/groovy/demo/PlayerControllerSpec.groovy[indent=0]
 ----
 
-<1> Call `update()` with values in `params`; binding fills the command object as at runtime.
+<1> Call the no-argument `update()` and put values in `params`. Databinding fills the command
+object. That is what happens at runtime.
+
+The current solution is still lacking. Because `PlayerInfo` is the command object, validation
+does not run until `player.save`. It is better to validate earlier, as when `Player` itself
+was the command object.
+
+When you define `PlayerInfo` in the same file as the controller, Grails makes it
+`Validateable`. Add a `constraints` block:
+
+[source,groovy]
+.grails-app/controllers/demo/PlayerController.groovy
+----
+include::../snippets/grails-app/controllers/demo/PlayerController.groovy[tags=playerInfo;playerInfo-constraints]
+----
+
+Create a unit test for those constraints:
 
 [source,groovy]
 .src/test/groovy/demo/PlayerInfoSpec.groovy
@@ -45,8 +190,35 @@ include::../snippets/src/test/groovy/demo/PlayerControllerSpec.groovy[indent=0]
 include::../snippets/src/test/groovy/demo/PlayerInfoSpec.groovy[indent=0]
 ----
 
-If you define the command class under `src/` instead of next to the controller, implement
-`grails.validation.Validateable` to keep a `constraints` block:
+Revise `update` once more so command-object errors are checked *before* the domain instance
+is loaded and saved. `respond info.errors, view: 'edit'` returns the error payload for API
+clients. For an HTML form post it also re-renders `edit.gsp`, but with a `playerInfo` model
+rather than `player`, so the scaffold form does not redisplay those errors. This beginner
+sample does not add an error-model bridge:
+
+[source,groovy]
+.grails-app/controllers/demo/PlayerController.groovy
+----
+include::../snippets/grails-app/controllers/demo/PlayerController.groovy[tags=update, indent=0]
+----
+
+The companion functional spec's second test posts a crafted update after a real save and
+asserts `wins` / `losses` stay unchanged while `game` and `region` update. Add this method
+(and the private helpers) to the spec from the previous chapter:
+
+[source,groovy]
+.src/integration-test/groovy/demo/PlayerControllerFuncSpec.groovy
+----
+include::../snippets/src/integration-test/groovy/demo/PlayerControllerFuncSpec.groovy[tags=updateIgnores]
+----
+
+Command object classes can be defined elsewhere (for example under `src/`). They need not
+live in the same file as the controller. That is useful for sharing a command object across
+controllers.
+
+**If the command object is in the same source file as the controller, Grails automatically
+makes it `Validateable`. If you define it elsewhere and need `constraints`, implement
+`Validateable`:**
 
 [source,groovy]
 ----

--- a/guides/command-objects-and-forms/v8/guide/createTheController.adoc
+++ b/guides/command-objects-and-forms/v8/guide/createTheController.adoc
@@ -1,5 +1,6 @@
-Create `grails-app/controllers/demo/PlayerController.groovy` with `index` and `show`
-actions that work with the existing `Player` domain:
+Before we can create any actions using command objects, we need a controller. Create
+`grails-app/controllers/demo/PlayerController.groovy` with `index` and `show` actions that
+work with the existing `Player` domain:
 
 [source,groovy]
 .grails-app/controllers/demo/PlayerController.groovy
@@ -7,11 +8,8 @@ actions that work with the existing `Player` domain:
 include::../snippets/grails-app/controllers/demo/PlayerController.groovy[tags=indexShow, indent=0]
 ----
 
-The domain class, views, and sample data are already in `initial/`. Run the app and open
-http://localhost:8080/player/ to list players and open a player detail page. Create,
-save, edit, and update are not wired yet.
+The domain class, views, and sample data are already in `initial/`. Run the application and
+open http://localhost:8080/player/ to see a list of players, and click a player's name to
+view that individual player. Create, save, edit, and update are not wired yet.
 
-[source,bash]
-----
-./gradlew bootRun
-----
+include::{commondir}/common-startTheApplication.adoc[]

--- a/guides/command-objects-and-forms/v8/guide/createTheController.adoc
+++ b/guides/command-objects-and-forms/v8/guide/createTheController.adoc
@@ -1,0 +1,17 @@
+Create `grails-app/controllers/demo/PlayerController.groovy` with `index` and `show`
+actions that work with the existing `Player` domain:
+
+[source,groovy]
+.grails-app/controllers/demo/PlayerController.groovy
+----
+include::../snippets/grails-app/controllers/demo/PlayerController.groovy[tags=indexShow, indent=0]
+----
+
+The domain class, views, and sample data are already in `initial/`. Run the app and open
+http://localhost:8080/player/ to list players and open a player detail page. Create,
+save, edit, and update are not wired yet.
+
+[source,bash]
+----
+./gradlew bootRun
+----

--- a/guides/command-objects-and-forms/v8/guide/gettingStarted.adoc
+++ b/guides/command-objects-and-forms/v8/guide/gettingStarted.adoc
@@ -1,0 +1,6 @@
+In this guide you use
+https://grails.apache.org/docs/latest/guide/theWebLayer.html#commandObjects[command objects]
+to process form submissions with automatic type conversion, custom validation, and
+simple error handling on Apache Grails 8.
+
+Work in the `initial/` project and compare your progress with `complete/`.

--- a/guides/command-objects-and-forms/v8/guide/helpWithGrails.adoc
+++ b/guides/command-objects-and-forms/v8/guide/helpWithGrails.adoc
@@ -1,0 +1,1 @@
+include::{commondir}/common-helpWithGrails.adoc[]

--- a/guides/command-objects-and-forms/v8/guide/howto.adoc
+++ b/guides/command-objects-and-forms/v8/guide/howto.adoc
@@ -4,7 +4,9 @@ Clone the companion and start from `initial/`:
 ----
 git clone -b grails8 https://github.com/grails-guides/command-objects-and-forms.git
 cd command-objects-and-forms/initial
-./gradlew test
+./gradlew bootRun
 ----
 
-`initial/` already includes the `Player` domain, scaffold views, and sample data. You will add `PlayerController` and the `PlayerInfo` command object. To skip ahead, use `complete/`.
+`initial/` already includes the `Player` domain, scaffold views, and sample data. You will add `PlayerController` and the `PlayerInfo` command object.
+
+To skip ahead, use `complete/` instead of `initial/`. Both trees must pass `./gradlew test integrationTest` (see `.github/workflows/grails8.yml`).

--- a/guides/command-objects-and-forms/v8/guide/howto.adoc
+++ b/guides/command-objects-and-forms/v8/guide/howto.adoc
@@ -1,0 +1,10 @@
+Clone the companion and start from `initial/`:
+
+[source,bash]
+----
+git clone -b grails8 https://github.com/grails-guides/command-objects-and-forms.git
+cd command-objects-and-forms/initial
+./gradlew test
+----
+
+`initial/` already includes the `Player` domain, scaffold views, and sample data. You will add `PlayerController` and the `PlayerInfo` command object. To skip ahead, use `complete/`.

--- a/guides/command-objects-and-forms/v8/guide/requirements.adoc
+++ b/guides/command-objects-and-forms/v8/guide/requirements.adoc
@@ -1,0 +1,4 @@
+* Approximately 45 minutes
+* JDK 21 (Apache Grails 8 requires Java 21)
+* A text editor or IDE
+* The Gradle wrapper bundled in `initial/` and `complete/`

--- a/guides/command-objects-and-forms/v8/guide/runningTheApp.adoc
+++ b/guides/command-objects-and-forms/v8/guide/runningTheApp.adoc
@@ -1,0 +1,15 @@
+From `complete/` (or your finished `initial/`):
+
+[source,bash]
+----
+./gradlew bootRun
+----
+
+Open http://localhost:8080/player — list, create, edit, and confirm wins/losses cannot be
+changed via the edit form or a crafted update request.
+
+[source,bash]
+----
+./gradlew test
+./gradlew integrationTest
+----

--- a/guides/command-objects-and-forms/v8/guide/runningTheApp.adoc
+++ b/guides/command-objects-and-forms/v8/guide/runningTheApp.adoc
@@ -5,11 +5,14 @@ From `complete/` (or your finished `initial/`):
 ./gradlew bootRun
 ----
 
-Open http://localhost:8080/player — list, create, edit, and confirm wins/losses cannot be
-changed via the edit form or a crafted update request.
+Open http://localhost:8080/player. List, create, and edit players. Confirm wins/losses cannot
+be changed via the edit form or a crafted update request.
 
 [source,bash]
 ----
 ./gradlew test
 ./gradlew integrationTest
 ----
+
+The integration spec covers save validation (`422` on a type-mismatched `losses` value) and
+the mass-assignment case (`wins` / `losses` ignored on update).

--- a/guides/command-objects-and-forms/v8/guide/whatAreCommandObjects.adoc
+++ b/guides/command-objects-and-forms/v8/guide/whatAreCommandObjects.adoc
@@ -1,0 +1,9 @@
+As described in the https://grails.apache.org/docs/latest/guide/theWebLayer.html#commandObjects[Grails documentation],
+____
+A command object is a class that is used in conjunction with data binding, usually to
+allow validation of data that may not fit into an existing domain class. *A class is only
+considered to be a command object when it is used as a parameter of an action.*
+____
+
+A domain class *can* be used as a command object. So can non-domain classes defined
+in other files, or even classes defined in the same file as the controller.

--- a/guides/command-objects-and-forms/v8/guide/writingTheApp.adoc
+++ b/guides/command-objects-and-forms/v8/guide/writingTheApp.adoc
@@ -1,0 +1,2 @@
+This guide walks through a controller whose actions use command objects so form
+input is handled safely with little boilerplate.

--- a/guides/command-objects-and-forms/v8/guide/writingTheApp.adoc
+++ b/guides/command-objects-and-forms/v8/guide/writingTheApp.adoc
@@ -1,2 +1,2 @@
 This guide walks through a controller whose actions use command objects so form
-input is handled safely with little boilerplate.
+input is bound, validated, and accepted only for the fields you expose.

--- a/guides/command-objects-and-forms/v8/snippets/grails-app/controllers/demo/PlayerController.groovy
+++ b/guides/command-objects-and-forms/v8/snippets/grails-app/controllers/demo/PlayerController.groovy
@@ -1,0 +1,101 @@
+// tag::indexShow[]
+package demo
+
+import grails.gorm.transactions.ReadOnly
+import grails.gorm.transactions.Transactional
+import org.springframework.http.HttpStatus
+
+@ReadOnly
+class PlayerController {
+
+    def index() {
+        respond Player.list(params), model: [playerCount: Player.count()]
+    }
+
+    def show(Player player) {
+        respond player
+    }
+    // end::indexShow[]
+
+    //tag::create[]
+    def create() {
+        respond new Player(params)
+    }
+    //end::create[]
+
+    //tag::save-full[]
+    //tag::save[]
+    @Transactional
+    def save(Player player) {
+        //end::save[]
+        //tag::save-handleErrors[]
+        if (player == null) {
+            render status: HttpStatus.NOT_FOUND
+            return
+        }
+
+        if (player.hasErrors()) {
+            respond player.errors, view: 'create'
+            return
+        }
+        //end::save-handleErrors[]
+
+        player.save flush: true
+
+        request.withFormat {
+            form multipartForm { redirect player }
+            '*' { respond player, status: HttpStatus.CREATED }
+        }
+        //tag::save[]
+    }
+    //end::save[]
+    //end::save-full[]
+
+    def edit(Player player) {
+        respond player
+    }
+
+    //tag::update[]
+    @Transactional
+    def update(PlayerInfo info) {
+        if (info.hasErrors()) {
+            respond info.errors, view: 'edit'
+            return
+        }
+        Player player = Player.get(params.id)
+        if (player == null) {
+            render status: HttpStatus.NOT_FOUND
+            return
+        }
+
+        player.properties = info.properties
+        player.save flush: true
+
+        request.withFormat {
+            form multipartForm { redirect player }
+            '*' { respond player, status: HttpStatus.OK }
+        }
+    }
+    //end::update[]
+
+//tag::indexShow[]
+}
+//end::indexShow[]
+
+//tag::playerInfo[]
+class PlayerInfo {
+    String name
+    String game
+    String region
+//end::playerInfo[]
+    //tag::playerInfo-constraints[]
+
+    static constraints = {
+        name blank: false
+        game blank: false
+        region nullable: true
+    }
+    //end::playerInfo-constraints[]
+//tag::playerInfo[]
+}
+//end::playerInfo[]

--- a/guides/command-objects-and-forms/v8/snippets/grails-app/controllers/demo/PlayerController.groovy
+++ b/guides/command-objects-and-forms/v8/snippets/grails-app/controllers/demo/PlayerController.groovy
@@ -69,7 +69,11 @@ class PlayerController {
         }
 
         player.properties = info.properties
-        player.save flush: true
+        if (!player.save(flush: true)) {
+            transactionStatus.setRollbackOnly()
+            respond player.errors, view: 'edit'
+            return
+        }
 
         request.withFormat {
             form multipartForm { redirect player }

--- a/guides/command-objects-and-forms/v8/snippets/grails-app/domain/demo/Player.groovy
+++ b/guides/command-objects-and-forms/v8/snippets/grails-app/domain/demo/Player.groovy
@@ -1,0 +1,17 @@
+package demo
+
+class Player {
+    String name
+    String game
+    String region
+    int wins = 0
+    int losses = 0
+
+    static constraints = {
+        name blank: false, unique: true
+        game blank: false
+        region nullable: true
+        wins min: 0
+        losses min: 0
+    }
+}

--- a/guides/command-objects-and-forms/v8/snippets/grails-app/views/player/create.gsp
+++ b/guides/command-objects-and-forms/v8/snippets/grails-app/views/player/create.gsp
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta name="layout" content="main" />
+        <g:set var="entityName" value="${message(code: 'player.label', default: 'Player')}" />
+        <title><g:message code="default.create.label" args="[entityName]" /></title>
+    </head>
+    <body>
+        <a href="#create-player" class="skip" tabindex="-1"><g:message code="default.link.skip.label" default="Skip to content&hellip;"/></a>
+        <div class="nav" role="navigation">
+            <ul>
+                <li><a class="home" href="${createLink(uri: '/')}"><g:message code="default.home.label"/></a></li>
+                <li><g:link class="list" action="index"><g:message code="default.list.label" args="[entityName]" /></g:link></li>
+            </ul>
+        </div>
+        <div id="create-player" class="content scaffold-create" role="main">
+            <h1><g:message code="default.create.label" args="[entityName]" /></h1>
+            <g:if test="${flash.message}">
+            <div class="message" role="status">${flash.message}</div>
+            </g:if>
+            <g:hasErrors bean="${this.player}">
+            <ul class="errors" role="alert">
+                <g:eachError bean="${this.player}" var="error">
+                <li <g:if test="${error in org.springframework.validation.FieldError}">data-field-id="${error.field}"</g:if>><g:message error="${error}"/></li>
+                </g:eachError>
+            </ul>
+            </g:hasErrors>
+            <g:form action="save">
+                <fieldset class="form">
+                    <f:all bean="player"/>
+                </fieldset>
+                <fieldset class="buttons">
+                    <g:submitButton name="create" class="save" value="${message(code: 'default.button.create.label', default: 'Create')}" />
+                </fieldset>
+            </g:form>
+        </div>
+    </body>
+</html>

--- a/guides/command-objects-and-forms/v8/snippets/grails-app/views/player/edit.gsp
+++ b/guides/command-objects-and-forms/v8/snippets/grails-app/views/player/edit.gsp
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta name="layout" content="main" />
+        <g:set var="entityName" value="${message(code: 'player.label', default: 'Player')}" />
+        <title><g:message code="default.edit.label" args="[entityName]" /></title>
+    </head>
+    <body>
+        <a href="#edit-player" class="skip" tabindex="-1"><g:message code="default.link.skip.label" default="Skip to content&hellip;"/></a>
+        <div class="nav" role="navigation">
+            <ul>
+                <li><a class="home" href="${createLink(uri: '/')}"><g:message code="default.home.label"/></a></li>
+                <li><g:link class="list" action="index"><g:message code="default.list.label" args="[entityName]" /></g:link></li>
+                <li><g:link class="create" action="create"><g:message code="default.new.label" args="[entityName]" /></g:link></li>
+            </ul>
+        </div>
+        <div id="edit-player" class="content scaffold-edit" role="main">
+            <h1><g:message code="default.edit.label" args="[entityName]" /></h1>
+            <g:if test="${flash.message}">
+            <div class="message" role="status">${flash.message}</div>
+            </g:if>
+            <g:hasErrors bean="${this.player}">
+            <ul class="errors" role="alert">
+                <g:eachError bean="${this.player}" var="error">
+                <li <g:if test="${error in org.springframework.validation.FieldError}">data-field-id="${error.field}"</g:if>><g:message error="${error}"/></li>
+                </g:eachError>
+            </ul>
+            </g:hasErrors>
+            <g:form resource="${this.player}" method="PUT">
+                <g:hiddenField name="version" value="${this.player?.version}" />
+                <fieldset class="form">
+                    <f:field bean="player" property="name" />
+                    <f:field bean="player" property="game" />
+                    <f:field bean="player" property="region" />
+                </fieldset>
+                <fieldset class="buttons">
+                    <input class="save" type="submit" value="${message(code: 'default.button.update.label', default: 'Update')}" />
+                </fieldset>
+            </g:form>
+        </div>
+    </body>
+</html>

--- a/guides/command-objects-and-forms/v8/snippets/src/integration-test/groovy/demo/PlayerControllerFuncSpec.groovy
+++ b/guides/command-objects-and-forms/v8/snippets/src/integration-test/groovy/demo/PlayerControllerFuncSpec.groovy
@@ -1,0 +1,33 @@
+package demo
+
+import grails.testing.mixin.integration.Integration
+import groovy.json.JsonSlurper
+import spock.lang.Specification
+
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+
+@Integration
+class PlayerControllerFuncSpec extends Specification {
+
+    void 'test save validation'() {
+        given:
+        HttpClient client = HttpClient.newHttpClient()
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create("http://localhost:${serverPort}/player/save.json"))
+                .header('Accept', 'application/json')
+                .header('Content-Type', 'application/x-www-form-urlencoded')
+                .POST(HttpRequest.BodyPublishers.ofString('name=Bob+Smith&wins=42&losses=abc'))
+                .build()
+
+        when:
+        HttpResponse<String> resp = client.send(request, HttpResponse.BodyHandlers.ofString())
+        Map body = new JsonSlurper().parseText(resp.body()) as Map
+        List errors = body.errors as List
+
+        then:
+        resp.statusCode() == 422 // <4>
+        errors.find { it.field == 'losses' }.message == 'Property losses is type-mismatched'
+    }
+}

--- a/guides/command-objects-and-forms/v8/snippets/src/integration-test/groovy/demo/PlayerControllerFuncSpec.groovy
+++ b/guides/command-objects-and-forms/v8/snippets/src/integration-test/groovy/demo/PlayerControllerFuncSpec.groovy
@@ -1,3 +1,4 @@
+// tag::saveSpec[]
 package demo
 
 import grails.testing.mixin.integration.Integration
@@ -11,13 +12,16 @@ import java.net.http.HttpResponse
 @Integration
 class PlayerControllerFuncSpec extends Specification {
 
+    HttpClient client = HttpClient.newBuilder()
+            .followRedirects(HttpClient.Redirect.NEVER)
+            .build()
+
     void 'test save validation'() {
         given:
-        HttpClient client = HttpClient.newHttpClient()
         HttpRequest request = HttpRequest.newBuilder()
-                .uri(URI.create("http://localhost:${serverPort}/player/save.json"))
-                .header('Accept', 'application/json')
-                .header('Content-Type', 'application/x-www-form-urlencoded')
+                .uri(URI.create("http://localhost:${serverPort}/player/save.json")) // <1>
+                .header('Accept', 'application/json') // <2>
+                .header('Content-Type', 'application/x-www-form-urlencoded') // <3>
                 .POST(HttpRequest.BodyPublishers.ofString('name=Bob+Smith&wins=42&losses=abc'))
                 .build()
 
@@ -30,4 +34,67 @@ class PlayerControllerFuncSpec extends Specification {
         resp.statusCode() == 422 // <4>
         errors.find { it.field == 'losses' }.message == 'Property losses is type-mismatched'
     }
+    // end::saveSpec[]
+
+    // tag::updateIgnores[]
+    void 'test update ignores wins and losses'() {
+        when: 'a player is created with known wins and losses'
+        HttpResponse<String> createdResp = postForm('/player/save.json', 'name=Mass+Assignment&game=Chess&region=NORTH&wins=10&losses=5')
+        def id = idFrom(createdResp)
+
+        then:
+        createdResp.statusCode() in [201, 302]
+        id != null
+
+        when: 'the saved player is fetched'
+        Map created = getJson("/player/show/${id}.json")
+
+        then:
+        created.wins == 10
+        created.losses == 5
+
+        when: 'a crafted request tries to change wins and losses'
+        HttpResponse<String> updateResp = postForm('/player/update.json', "id=${id}&name=Mass+Assignment&game=Go&region=EAST&wins=2&losses=194")
+        Map after = getJson("/player/show/${id}.json")
+
+        then: 'editable fields change, wins and losses do not'
+        updateResp.statusCode() in [200, 302]
+        after.name == 'Mass Assignment'
+        after.game == 'Go'
+        after.region == 'EAST'
+        after.wins == 10
+        after.losses == 5
+    }
+
+    private HttpResponse<String> postForm(String path, String body) {
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create("http://localhost:${serverPort}${path}"))
+                .header('Accept', 'application/json')
+                .header('Content-Type', 'application/x-www-form-urlencoded')
+                .POST(HttpRequest.BodyPublishers.ofString(body))
+                .build()
+        client.send(request, HttpResponse.BodyHandlers.ofString())
+    }
+
+    private Map getJson(String path) {
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create("http://localhost:${serverPort}${path}"))
+                .header('Accept', 'application/json')
+                .GET()
+                .build()
+        HttpResponse<String> resp = client.send(request, HttpResponse.BodyHandlers.ofString())
+        assert resp.statusCode() == 200
+        new JsonSlurper().parseText(resp.body()) as Map
+    }
+
+    private static Serializable idFrom(HttpResponse<String> resp) {
+        if (resp.statusCode() == 201 && resp.body()) {
+            return new JsonSlurper().parseText(resp.body()).id
+        }
+        resp.headers().firstValue('Location').orElse(null)?.split('/')?.last()
+    }
+    // end::updateIgnores[]
+
+// tag::saveSpec[]
 }
+// end::saveSpec[]

--- a/guides/command-objects-and-forms/v8/snippets/src/test/groovy/demo/PlayerControllerSpec.groovy
+++ b/guides/command-objects-and-forms/v8/snippets/src/test/groovy/demo/PlayerControllerSpec.groovy
@@ -1,0 +1,32 @@
+package demo
+
+import grails.testing.gorm.DomainUnitTest
+import grails.testing.web.controllers.ControllerUnitTest
+import spock.lang.Specification
+
+class PlayerControllerSpec extends Specification implements ControllerUnitTest<PlayerController>, DomainUnitTest<Player> {
+
+    def 'test update'() {
+        when:
+        def player = new Player(name: 'Sergio', game: 'XCOM: Enemy Unkown', region: 'Spain', wins: 3, losses: 2)
+        player.save()
+        params.id = player.id
+        params.name = 'Sergio del Amo'
+        params.game = 'XCOM 2'
+        params.region = 'USA'
+        params.wins = 4
+        controller.update() // <1>
+
+        then: 'respond model has no errors'
+        !model.player.hasErrors()
+
+        and: 'player properties have been updated correctly'
+        model.player.name == 'Sergio del Amo'
+        model.player.game == 'XCOM 2'
+        model.player.region == 'USA'
+
+        and: 'non existing properties in the command object have not been modified'
+        model.player.wins == 3
+        model.player.losses == 2
+    }
+}

--- a/guides/command-objects-and-forms/v8/snippets/src/test/groovy/demo/PlayerControllerSpec.groovy
+++ b/guides/command-objects-and-forms/v8/snippets/src/test/groovy/demo/PlayerControllerSpec.groovy
@@ -1,3 +1,4 @@
+// tag::updateSpec[]
 package demo
 
 import grails.testing.gorm.DomainUnitTest
@@ -29,4 +30,28 @@ class PlayerControllerSpec extends Specification implements ControllerUnitTest<P
         model.player.wins == 3
         model.player.losses == 2
     }
+    // end::updateSpec[]
+
+    // tag::uniqueSpec[]
+    def 'test update reports a duplicate name'() {
+        given:
+        new Player(name: 'Taken', game: 'Chess', region: 'EAST', wins: 1, losses: 0).save(flush: true)
+        def player = new Player(name: 'Free', game: 'Go', region: 'WEST', wins: 2, losses: 1).save(flush: true)
+
+        when:
+        params.id = player.id
+        params.name = 'Taken'
+        params.game = 'Go'
+        params.region = 'WEST'
+        controller.update()
+
+        then:
+        view == 'edit'
+        model.player.hasErrors()
+        model.player.errors['name']?.code == 'unique'
+    }
+    // end::uniqueSpec[]
+
+// tag::updateSpec[]
 }
+// end::updateSpec[]

--- a/guides/command-objects-and-forms/v8/snippets/src/test/groovy/demo/PlayerInfoSpec.groovy
+++ b/guides/command-objects-and-forms/v8/snippets/src/test/groovy/demo/PlayerInfoSpec.groovy
@@ -1,0 +1,43 @@
+package demo
+
+import spock.lang.Specification
+
+class PlayerInfoSpec extends Specification {
+
+    def 'test PlayerInfo.region can be null'() {
+        expect:
+        new PlayerInfo(region: null).validate(['region'])
+    }
+
+    def 'test PlayerInfo.name cannot be blank'() {
+        when:
+        def playerInfo = new PlayerInfo(name: '')
+
+        then:
+        !playerInfo.validate(['name'])
+        playerInfo.errors['name'].code == 'blank'
+
+        when:
+        playerInfo = new PlayerInfo(name: null)
+
+        then:
+        !playerInfo.validate(['name'])
+        playerInfo.errors['name'].code == 'nullable'
+    }
+
+    def 'test PlayerInfo.game cannot be blank'() {
+        when:
+        def playerInfo = new PlayerInfo(game: '')
+
+        then:
+        !playerInfo.validate(['game'])
+        playerInfo.errors['game'].code == 'blank'
+
+        when:
+        playerInfo = new PlayerInfo(game: null)
+
+        then:
+        !playerInfo.validate(['game'])
+        playerInfo.errors['game'].code == 'nullable'
+    }
+}


### PR DESCRIPTION
Adds the Grails 8 command-objects-and-forms guide under `guides/command-objects-and-forms/v8/` (AsciiDoc chapters + vendored snippets from `complete/`) and registers `versions['8']` in `conf/guides.yml`.

Companion: grails-guides/command-objects-and-forms (branch `grails8`)