### PR TITLE
Allow Forge API hosts in grails.apache.org CSP

### DIFF
--- a/buildSrc/src/main/groovy/website/gradle/tasks/HtaccessTask.groovy
+++ b/buildSrc/src/main/groovy/website/gradle/tasks/HtaccessTask.groovy
@@ -40,6 +40,7 @@ abstract class HtaccessTask extends GrailsWebsiteTask {
     public static final String NAME = 'genHtaccess'
 
     private static final List<String> DOMAINS = [
+            'https://*.grails.org/', // Forge UI at /start/ fetches latest/next/snapshot/prev.grails.org
             'https://*.kapa.ai/',
             'https://kapa-widget-proxy-la7dkmplpq-uc.a.run.app',
             'https://www.google.com/recaptcha/',


### PR DESCRIPTION
## Summary

- Add `https://*.grails.org/` to `HtaccessTask` `CSP_PROJECT_DOMAINS`.
- The Application Forge at https://grails.apache.org/start/ fetches `latest` / `next` / `snapshot` / `prev` / `prev-snapshot`.grails.org. Those hosts were not in the site CSP, so the browser blocked every API `fetch()` (`default-src` fallback; no `connect-src`).
- Matches existing wildcard style (`https://*.kapa.ai/`). ASF INFRA-27297.

Companion: font CSP cleanup in apache/grails-forge-ui.

## Test plan

- [ ] After this publishes to `asf-site-production`, `grails.apache.org` CSP includes `https://*.grails.org/`.
- [ ] https://grails.apache.org/start/ can load `/versions` from latest.grails.org without a CSP connect/default-src error.
- [ ] Kapa / recaptcha still work on the main site.
