### PR TITLE
Allow Forge API hosts as CSP host-only sources

### DIFF
--- a/buildSrc/src/main/groovy/website/gradle/tasks/HtaccessTask.groovy
+++ b/buildSrc/src/main/groovy/website/gradle/tasks/HtaccessTask.groovy
@@ -40,7 +40,14 @@ abstract class HtaccessTask extends GrailsWebsiteTask {
     public static final String NAME = 'genHtaccess'
 
     private static final List<String> DOMAINS = [
-            'https://*.grails.org/', // Forge UI at /start/ fetches latest/next/snapshot/prev.grails.org
+            // Host-only (no path). Trailing slash on a wildcard host is ignored by
+            // some browsers, which blocked Forge UI fetches to /versions.
+            'https://*.grails.org',
+            'https://latest.grails.org',
+            'https://next.grails.org',
+            'https://snapshot.grails.org',
+            'https://prev.grails.org',
+            'https://prev-snapshot.grails.org',
             'https://*.kapa.ai/',
             'https://kapa-widget-proxy-la7dkmplpq-uc.a.run.app',
             'https://www.google.com/recaptcha/',


### PR DESCRIPTION
## What

Change `CSP_PROJECT_DOMAINS` from `https://*.grails.org/` (wildcard + trailing slash) to host-only sources:

- `https://*.grails.org`
- `https://latest.grails.org`
- `https://next.grails.org`
- `https://snapshot.grails.org`
- `https://prev.grails.org`
- `https://prev-snapshot.grails.org`

This matches the existing `https://*.hcaptcha.com` pattern.

## Why

Forge UI at `/start/` fetches `/versions` on those API hosts. `connect-src` falls back to `default-src`. A path of `/` on a wildcard host did not reliably allow those fetches in Edge/Firefox even when origin `.htaccess` looked correct.

## Test plan

- [x] Live origin `.htaccess` already includes `https://*.grails.org/`
- [x] `GET https://latest.grails.org/versions` with `Origin: https://grails.apache.org` returns 200 + CORS
- [ ] After publish, live CSP lists the host-only sources (no trailing slash on `*.grails.org`)
- [ ] Hard-refresh `https://grails.apache.org/start/` in Edge and Firefox; `/versions` fetches succeed
