### PR TITLE
Replace dead start.grails.org curl ZIP examples

### DIFF
--- a/guides/common/common-grailsApplicationForge-grails3.adoc
+++ b/guides/common/common-grailsApplicationForge-grails3.adoc
@@ -2,10 +2,5 @@
 ====
 Did you know you can download a complete Grails project without installing any additional tools? Go to https://grails.apache.org/start/[grails.apache.org/start] and use the *Grails Application Forge* to generate your Grails project. You can choose your project type (Application or Plugin), pick a version of Grails, and choose a Profile - then click "Generate Project" to download a ZIP file. No Grails installation necessary!
 
-You can even download your project from the command line using a HTTP tool like `curl`:
-
-[source, bash]
-----
-curl -O start.grails.org/myapp.zip -d version=3.3.11 -d profile=angular
-----
+The old `start.grails.org` curl API no longer serves versioned zips. Use the Forge UI to pick a Grails version.
 ====

--- a/guides/common/common-grailsApplicationForge.adoc
+++ b/guides/common/common-grailsApplicationForge.adoc
@@ -2,10 +2,5 @@
 ====
 Did you know you can download a complete Grails project without installing any additional tools? Go to https://grails.apache.org/start/[grails.apache.org/start] and use the *Grails Application Forge* to generate your Grails project. You can choose your project type (Application or Plugin), pick a version of Grails, and choose a Profile - then click "Generate Project" to download a ZIP file. No Grails installation necessary!
 
-You can even download your project from the command line using a HTTP tool like `curl`:
-
-[source, bash]
-----
-curl -O start.grails.org/myapp.zip -d version=4.0.1
-----
+The old `start.grails.org` curl API no longer serves versioned zips. Use the Forge UI to pick a Grails version.
 ====

--- a/guides/common/common-grailsApplicationForge5.adoc
+++ b/guides/common/common-grailsApplicationForge5.adoc
@@ -2,10 +2,5 @@
 ====
 Did you know you can download a complete Grails project without installing any additional tools? Go to https://grails.apache.org/start/[grails.apache.org/start] and use the *Grails Application Forge* to generate your Grails project. You can choose your project type (Application or Plugin), pick a version of Grails, and choose a Profile - then click "Generate Project" to download a ZIP file. No Grails installation necessary!
 
-You can even download your project from the command line using a HTTP tool like `curl`:
-
-[source, bash]
-----
-curl -O start.grails.org/myapp.zip -d version=5.1.6
-----
+The old `start.grails.org` curl API no longer serves versioned zips. Use the Forge UI to pick a Grails version.
 ====

--- a/guides/common/ommon-grailsApplicationForge5.adoc
+++ b/guides/common/ommon-grailsApplicationForge5.adoc
@@ -2,10 +2,5 @@
 ====
 Did you know you can download a complete Grails project without installing any additional tools? Go to https://grails.apache.org/start/[grails.apache.org/start] and use the *Grails Application Forge* to generate your Grails project. You can choose your project type (Application or Plugin), pick a version of Grails, and choose a Profile - then click "Generate Project" to download a ZIP file. No Grails installation necessary!
 
-You can even download your project from the command line using a HTTP tool like `curl`:
-
-[source, bash]
-----
-curl -O start.grails.org/myapp.zip -d version=5.1.6
-----
+The old `start.grails.org` curl API no longer serves versioned zips. Use the Forge UI to pick a Grails version.
 ====

--- a/guides/grails-transactional-events/v8/guide/download.adoc
+++ b/guides/grails-transactional-events/v8/guide/download.adoc
@@ -2,7 +2,7 @@ Generate a Grails 8 starter from link:https://grails.apache.org/start/[grails.ap
 
 [source,bash]
 ----
-curl https://next.grails.org/create/WEB/grails-transactional-events -o grails-transactional-events.zip
+curl https://latest.grails.org/create/WEB/grails-transactional-events -o grails-transactional-events.zip
 unzip grails-transactional-events.zip -d grails-transactional-events
 cd grails-transactional-events
 ----

--- a/guides/grails-transactional-events/v8/guide/download.adoc
+++ b/guides/grails-transactional-events/v8/guide/download.adoc
@@ -2,7 +2,7 @@ Generate a Grails 8 starter from link:https://grails.apache.org/start/[grails.ap
 
 [source,bash]
 ----
-curl -sL "https://start.grails.org/grails/grails-transactional-events.zip?type=web&javaVersion=21&grailsVersion=8.0.0" -o grails-transactional-events.zip
+curl https://next.grails.org/create/WEB/grails-transactional-events -o grails-transactional-events.zip
 unzip grails-transactional-events.zip -d grails-transactional-events
 cd grails-transactional-events
 ----

--- a/guides/grails_url_mappings/v4/guide/creatingTheApp.adoc
+++ b/guides/grails_url_mappings/v4/guide/creatingTheApp.adoc
@@ -11,12 +11,7 @@ If you have Grails (>= 3.3.0) installed, you can create your application on the 
 
 === 2. Create a new Application via the Application Forge
 
-You can download your project from the online wizard at https://grails.apache.org/start/, or with the following `curl` command:
-
-[source,bash]
-----
-~ curl -O start.grails.org/agenda.zip -d version=3.3.2
-----
+You can download your project from the online wizard at https://grails.apache.org/start/. The old `start.grails.org` curl API no longer serves versioned zips.
 
 === 3. Use the Initial Project from the Guide Repo
 

--- a/guides/using-the-react-profile/v4/guide/generateTheApp.adoc
+++ b/guides/using-the-react-profile/v4/guide/generateTheApp.adoc
@@ -5,12 +5,7 @@ To get started with this profile, specify it when generating your app:
 $ grails create-app myApp --profile=react
 ----
 
-You can also generate your project using the https://grails.apache.org/start/[Application Forge], either from the web interface or using the following `curl` command:
-
-[source,bash]
-----
-curl -O start.grails.org/myApp.zip -d version=3.3.2 -d profile=react
-----
+You can also generate your project using the https://grails.apache.org/start/[Application Forge] web interface. The old `start.grails.org` curl API no longer serves profile-specific zips.
 
 
 Take a look at the directory structure - you will see a typical Gradle multi-project build, with separate client and server projects.

--- a/guides/using-the-vue-profile/v3/guide/generateTheApp.adoc
+++ b/guides/using-the-vue-profile/v3/guide/generateTheApp.adoc
@@ -5,12 +5,7 @@ To get started with this profile, specify it when generating your app:
 $ grails create-app myApp --profile=vue
 ----
 
-You can also generate your project using the https://grails.apache.org/start/[Application Forge], either from the web interface or using the following `curl` command:
-
-[source,bash]
-----
-curl -O start.grails.org/myApp.zip -d version=3.3.3 -d profile=vue
-----
+You can also generate your project using the https://grails.apache.org/start/[Application Forge] web interface. The old `start.grails.org` curl API no longer serves profile-specific zips.
 
 
 Take a look at the directory structure - you will see a typical Gradle multi-project build, with separate client and server projects.

--- a/guides/using-the-vue-profile/v4/guide/generateTheApp.adoc
+++ b/guides/using-the-vue-profile/v4/guide/generateTheApp.adoc
@@ -5,12 +5,7 @@ To get started with this profile, specify it when generating your app:
 $ grails create-app myApp --profile=vue
 ----
 
-You can also generate your project using the https://grails.apache.org/start/[Application Forge], either from the web interface or using the following `curl` command:
-
-[source,bash]
-----
-curl -O start.grails.org/myApp.zip -d version=4.0.1 -d profile=vue
-----
+You can also generate your project using the https://grails.apache.org/start/[Application Forge] web interface. The old `start.grails.org` curl API no longer serves profile-specific zips.
 
 
 Take a look at the directory structure - you will see a typical Gradle multi-project build, with separate client and server projects.

--- a/posts/2017-11-21.md
+++ b/posts/2017-11-21.md
@@ -23,11 +23,7 @@ This profile provides a monolithic project structure with React code embedded wi
 grails create-app myapp -profile react-weback
 ```
 
-You can also choose this project when generating your project from the [Grails Application Forge](https://grails.apache.org/start/), either from the web app or via the API:
-
-```
-curl -O start.grails.org/myapp.zip -d profile=react-webpack
-```
+You can also choose this project when generating your project from the [Grails Application Forge](https://grails.apache.org/start/). The old `start.grails.org` curl API no longer serves the `react-webpack` profile.
 
 Besides the convenience of having a distinct name for the project, the new name better reflects the dependence of the `react-webpack` profile on its parent profile, `webpack`. You can use the `webpack` profile directly if you want to pick your own frontend JavaScript libraries in your project.
 

--- a/posts/2017-11-21.md
+++ b/posts/2017-11-21.md
@@ -23,7 +23,7 @@ This profile provides a monolithic project structure with React code embedded wi
 grails create-app myapp -profile react-weback
 ```
 
-You can also choose this project when generating your project from the [Grails Application Forge](https://grails.apache.org/start/). The old `start.grails.org` curl API no longer serves the `react-webpack` profile.
+You can also generate a project from the [Grails Application Forge](https://grails.apache.org/start/). The old `start.grails.org` curl API no longer serves ZIP downloads.
 
 Besides the convenience of having a distinct name for the project, the new name better reflects the dependence of the `react-webpack` profile on its parent profile, `webpack`. You can use the `webpack` profile directly if you want to pick your own frontend JavaScript libraries in your project.
 

--- a/posts/2017-12-05.md
+++ b/posts/2017-12-05.md
@@ -23,7 +23,7 @@ From Rob Fletcher book, [Spock: Up and Running](https://shop.oreilly.com/product
 
 In this blog post, we discuss how to avoid test leakage in Grails<sup>&reg;</sup> integration and functional tests. In particular, _data in a persistent store that is not removed_. 
 
-Lets us create a simple Grails App from the [Grails Application Forge](https://grails.apache.org/start/). The old `start.grails.org` curl API no longer serves versioned zips.
+Let's create a simple Grails App from the [Grails Application Forge](https://grails.apache.org/start/). The old `start.grails.org` curl API no longer serves ZIP downloads.
 
 with a Domain Class 
 

--- a/posts/2017-12-05.md
+++ b/posts/2017-12-05.md
@@ -23,9 +23,7 @@ From Rob Fletcher book, [Spock: Up and Running](https://shop.oreilly.com/product
 
 In this blog post, we discuss how to avoid test leakage in Grails<sup>&reg;</sup> integration and functional tests. In particular, _data in a persistent store that is not removed_. 
 
-Lets us create a simple Grails App: 
-
-    curl -O start.grails.org/myapp.zip -d version=3.3.2 -d profile=rest-api
+Lets us create a simple Grails App from the [Grails Application Forge](https://grails.apache.org/start/). The old `start.grails.org` curl API no longer serves versioned zips.
 
 with a Domain Class 
 


### PR DESCRIPTION
## What

`start.grails.org` now redirects to the Forge UI and no longer serves ZIP downloads.

- Historical versioned/profile-specific `curl` examples are removed. Those guides now send people to https://grails.apache.org/start/.
- The Grails 8 transactional-events example uses `https://next.grails.org/create/WEB/grails-transactional-events` (Grails 8.0.0-M5). `latest.grails.org` is Grails 7.2.3.
