### PR TITLE
Retry publishMainSite on concurrent asf-site-production pushes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,10 +9,11 @@ on:
 # Serialize this repo's own overlapping publishes (push vs cron). Cross-repo
 # races against grails-core on apache/grails-website asf-site-production are
 # retried by publishMainSite (same non-fast-forward rebase as
-# apache/grails-github-actions#110). deploy-github-pages is not used here:
-# that action publishes into docs/<snapshot|version>, stages with
-# `git add $path/*` (skips .htaccess and .well-known), and a root purge
-# would delete grails-core's docs/ tree.
+# apache/grails-github-actions#110). Keep :publishMainSite instead of
+# deploy-github-pages: that action can push this same target repo/branch
+# (grails-core already does, with TARGET_FOLDER: docs), but a root overlay
+# with default PURGE_EXISTING would wipe docs/, and `git add $path/*`
+# skips new root .htaccess / .well-known.
 concurrency:
   group: publish-${{ github.ref }}
   cancel-in-progress: false

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,15 +6,20 @@ on:
   schedule:
     - cron:  '0 */2 * * *'
   workflow_dispatch:
-# Prevent two simultaneous publishes from racing on the deploy branch.
-# cancel-in-progress=false so the in-flight deploy completes before the next.
+# Serialize this repo's own overlapping publishes (push vs cron). Cross-repo
+# races against grails-core on apache/grails-website asf-site-production are
+# retried by publishMainSite (same non-fast-forward rebase as
+# apache/grails-github-actions#110). deploy-github-pages is not used here:
+# that action publishes into docs/<snapshot|version>, stages with
+# `git add $path/*` (skips .htaccess and .well-known), and a root purge
+# would delete grails-core's docs/ tree.
 concurrency:
   group: publish-${{ github.ref }}
   cancel-in-progress: false
 jobs:
   build:
     permissions:
-      contents: write
+      contents: read
     if: github.repository == 'apache/grails-static-website'
     runs-on: ubuntu-latest
     steps:
@@ -55,4 +60,3 @@ jobs:
           GH_TOKEN: ${{ secrets.GRAILS_GHTOKEN }}
           GH_BRANCH: asf-site-production
           GRAILS_WS_URL: https://grails.apache.org
-

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 Source for the Apache Grails website at [https://grails.apache.org/](https://grails.apache.org/) and the guides site at [https://grails.apache.org/guides/](https://grails.apache.org/guides/). Built as a static site with [Gradle](https://gradle.org); the build logic lives in [`buildSrc/`](buildSrc/).
 
-The cron-driven [`publish.yml`](.github/workflows/publish.yml) workflow builds this repository and pushes the result to the [`asf-site-production` branch on `apache/grails-website`](https://github.com/apache/grails-website/tree/asf-site-production), which Apache Infra mirrors to `grails.apache.org`.
+The cron-driven [`publish.yml`](.github/workflows/publish.yml) workflow builds this repository and pushes the result to the [`asf-site-production` branch on `apache/grails-website`](https://github.com/apache/grails-website/tree/asf-site-production), which Apache Infra mirrors to `grails.apache.org`. Concurrent documentation pushes from Grails Core are retried with the same non-fast-forward rebase as [`deploy-github-pages` PR #110](https://github.com/apache/grails-github-actions/pull/110).
 
 The legacy `https://guides.grails.org/` host is kept alive serving meta-refresh redirects to the new canonical URLs.
 

--- a/buildSrc/src/main/groovy/website/gradle/tasks/PublishMainSiteTask.groovy
+++ b/buildSrc/src/main/groovy/website/gradle/tasks/PublishMainSiteTask.groovy
@@ -73,7 +73,10 @@ import java.nio.file.attribute.BasicFileAttributes
  *       {@code .git/} metadata).</li>
  *   <li>Stages all changes; if {@code git status --porcelain} is empty,
  *       reports "no changes" and exits 0 without pushing.</li>
- *   <li>Otherwise commits and pushes back to {@code GH_BRANCH}.</li>
+ *   <li>Otherwise commits and pushes back to {@code GH_BRANCH}. Concurrent
+ *       non-fast-forward rejections are retried (fetch, descendant check,
+ *       rebase of the unpublished commit) up to five attempts, matching
+ *       apache/grails-github-actions#110. There is no force-push.</li>
  * </ol>
  *
  * The task uses {@link ExecOperations} (configuration-cache compatible)
@@ -233,17 +236,93 @@ abstract class PublishMainSiteTask extends DefaultTask {
             return
         }
 
-        // 6. Commit + push.
+        // 6. Commit + push. Retry genuine non-fast-forward races the same way
+        // apache/grails-github-actions#110 does for deploy-github-pages: fetch
+        // the new tip, require it to descend from the tip we cloned, rebase
+        // the unpublished local commit, and push again. Never force-push.
+        // deploy-github-pages itself is not a drop-in here: it publishes into
+        // docs/<snapshot|version>, and `git add $path/*` skips root .htaccess
+        // and .well-known.
+        String lastRemoteTip = captureGit(deployRoot, 'rev-parse', 'HEAD')
         String commitMessage = "Updating ${slug} ${branch} branch for GitHub Actions run:${run}"
         runGit(deployRoot, 'commit', '-m', commitMessage)
-        // Re-use the credential-bearing URL so this push does not depend on
-        // any global git credential helper state.
         String pushUrl = "https://oauth2:${token}@github.com/${slug}.git"
-        runGit(deployRoot, 'push', pushUrl, branch)
+        pushWithRetry(deployRoot, pushUrl, branch, lastRemoteTip)
+    }
+
+    private static final int MAX_PUSH_ATTEMPTS = 5
+
+    static boolean retryablePushRejection(String output) {
+        output.readLines().any { String line ->
+            line ==~ /^!\t.*\t\[rejected\] \((non-fast-forward|fetch first)\)$/
+        }
+    }
+
+    void pushWithRetry(File deployRoot, String pushUrl, String branch, String lastRemoteTip) {
+        String observedTip = lastRemoteTip
+        for (int attempt = 1; attempt <= MAX_PUSH_ATTEMPTS; attempt++) {
+            logger.lifecycle("Push attempt ${attempt}/${MAX_PUSH_ATTEMPTS}")
+            ByteArrayOutputStream combined = new ByteArrayOutputStream()
+            int exit = exec.exec { spec ->
+                spec.workingDir = deployRoot
+                spec.commandLine = ['git', '-c', 'core.hooksPath=', 'push', '--porcelain', pushUrl, "HEAD:refs/heads/${branch}".toString()]
+                spec.environment('LC_ALL', 'C')
+                spec.standardOutput = combined
+                spec.errorOutput = combined
+                spec.ignoreExitValue = true
+            }.exitValue
+            String output = new String(combined.toByteArray(), 'UTF-8')
+            if (!output.empty) {
+                logger.lifecycle(output)
+            }
+            if (exit == 0) {
+                logger.lifecycle('Deployment successful!')
+                return
+            }
+            boolean retryable = retryablePushRejection(output)
+            if (!retryable) {
+                throw new GradleException('Push failed without a retryable non-fast-forward rejection.')
+            }
+            if (attempt == MAX_PUSH_ATTEMPTS) {
+                throw new GradleException("Push failed after ${MAX_PUSH_ATTEMPTS} attempts.")
+            }
+            logger.lifecycle('Push rejected by a concurrent publisher, rebasing and retrying...')
+            if (!Boolean.getBoolean('website.publish.skipRetryBackoff')) {
+                int backoffSeconds = 1 << (attempt - 1)
+                Thread.sleep((backoffSeconds + new Random().nextInt(backoffSeconds + 1)) * 1000L)
+            }
+            runGit(deployRoot, 'fetch', '--no-tags', pushUrl, "refs/heads/${branch}")
+            String newRemoteTip = captureGit(deployRoot, 'rev-parse', 'FETCH_HEAD')
+            ByteArrayOutputStream ancestorOut = new ByteArrayOutputStream()
+            int ancestorExit = exec.exec { spec ->
+                spec.workingDir = deployRoot
+                spec.commandLine = ['git', 'merge-base', '--is-ancestor', observedTip, newRemoteTip]
+                spec.standardOutput = ancestorOut
+                spec.errorOutput = ancestorOut
+                spec.ignoreExitValue = true
+            }.exitValue
+            if (newRemoteTip == observedTip || ancestorExit != 0) {
+                throw new GradleException('Concurrent documentation branch update is not a descendant of the observed remote tip.')
+            }
+            int rebaseExit = exec.exec { spec ->
+                spec.workingDir = deployRoot
+                spec.commandLine = ['git', 'rebase', '--onto', newRemoteTip, observedTip]
+                spec.ignoreExitValue = true
+            }.exitValue
+            if (rebaseExit != 0) {
+                exec.exec { spec ->
+                    spec.workingDir = deployRoot
+                    spec.commandLine = ['git', 'rebase', '--abort']
+                    spec.ignoreExitValue = true
+                }
+                throw new GradleException('Rebase failed; aborting without changing the remote branch.')
+            }
+            observedTip = newRemoteTip
+        }
     }
 
     private void runGit(File workingDir, String... args) {
-        List<String> cmd = ['git']
+        List<String> cmd = ['git', '-c', 'core.hooksPath=']
         cmd.addAll(args.toList())
         exec.exec { spec ->
             spec.workingDir = workingDir
@@ -252,7 +331,7 @@ abstract class PublishMainSiteTask extends DefaultTask {
     }
 
     private String captureGit(File workingDir, String... args) {
-        List<String> cmd = ['git']
+        List<String> cmd = ['git', '-c', 'core.hooksPath=']
         cmd.addAll(args.toList())
         ByteArrayOutputStream out = new ByteArrayOutputStream()
         exec.exec { spec ->

--- a/buildSrc/src/main/groovy/website/gradle/tasks/PublishMainSiteTask.groovy
+++ b/buildSrc/src/main/groovy/website/gradle/tasks/PublishMainSiteTask.groovy
@@ -240,8 +240,10 @@ abstract class PublishMainSiteTask extends DefaultTask {
         // apache/grails-github-actions#110 does for deploy-github-pages: fetch
         // the new tip, require it to descend from the tip we cloned, rebase
         // the unpublished local commit, and push again. Never force-push.
-        // deploy-github-pages itself is not a drop-in here: it publishes into
-        // docs/<snapshot|version>, and `git add $path/*` skips root .htaccess
+        // Keep Gradle rather than calling the action: it can target this
+        // same repo/branch (TARGET_FOLDER defaults to `.`; grails-core sets
+        // docs/), but default PURGE_EXISTING would wipe grails-core docs/
+        // on a root overlay, and `git add $path/*` skips new root .htaccess
         // and .well-known.
         String lastRemoteTip = captureGit(deployRoot, 'rev-parse', 'HEAD')
         String commitMessage = "Updating ${slug} ${branch} branch for GitHub Actions run:${run}"

--- a/buildSrc/src/main/groovy/website/gradle/tasks/PublishMainSiteTask.groovy
+++ b/buildSrc/src/main/groovy/website/gradle/tasks/PublishMainSiteTask.groovy
@@ -258,6 +258,10 @@ abstract class PublishMainSiteTask extends DefaultTask {
         }
     }
 
+    static String redactAuthenticatedUrls(String output) {
+        output.replaceAll(/https:\/\/[^\/\s@]+@([^\/\s]+)/, 'https://***@$1')
+    }
+
     void pushWithRetry(File deployRoot, String pushUrl, String branch, String lastRemoteTip) {
         String observedTip = lastRemoteTip
         for (int attempt = 1; attempt <= MAX_PUSH_ATTEMPTS; attempt++) {
@@ -273,7 +277,7 @@ abstract class PublishMainSiteTask extends DefaultTask {
             }.exitValue
             String output = new String(combined.toByteArray(), 'UTF-8')
             if (!output.empty) {
-                logger.lifecycle(output)
+                logger.lifecycle(redactAuthenticatedUrls(output))
             }
             if (exit == 0) {
                 logger.lifecycle('Deployment successful!')
@@ -296,23 +300,23 @@ abstract class PublishMainSiteTask extends DefaultTask {
             ByteArrayOutputStream ancestorOut = new ByteArrayOutputStream()
             int ancestorExit = exec.exec { spec ->
                 spec.workingDir = deployRoot
-                spec.commandLine = ['git', 'merge-base', '--is-ancestor', observedTip, newRemoteTip]
+                spec.commandLine = ['git', '-c', 'core.hooksPath=', 'merge-base', '--is-ancestor', observedTip, newRemoteTip]
                 spec.standardOutput = ancestorOut
                 spec.errorOutput = ancestorOut
                 spec.ignoreExitValue = true
             }.exitValue
             if (newRemoteTip == observedTip || ancestorExit != 0) {
-                throw new GradleException('Concurrent documentation branch update is not a descendant of the observed remote tip.')
+                throw new GradleException("Concurrent branch update is not a descendant of observed tip ${observedTip}; new remote tip is ${newRemoteTip}.")
             }
             int rebaseExit = exec.exec { spec ->
                 spec.workingDir = deployRoot
-                spec.commandLine = ['git', 'rebase', '--onto', newRemoteTip, observedTip]
+                spec.commandLine = ['git', '-c', 'core.hooksPath=', 'rebase', '--onto', newRemoteTip, observedTip]
                 spec.ignoreExitValue = true
             }.exitValue
             if (rebaseExit != 0) {
                 exec.exec { spec ->
                     spec.workingDir = deployRoot
-                    spec.commandLine = ['git', 'rebase', '--abort']
+                    spec.commandLine = ['git', '-c', 'core.hooksPath=', 'rebase', '--abort']
                     spec.ignoreExitValue = true
                 }
                 throw new GradleException('Rebase failed; aborting without changing the remote branch.')
@@ -388,3 +392,4 @@ abstract class PublishMainSiteTask extends DefaultTask {
         })
     }
 }
+

--- a/buildSrc/src/test/groovy/website/gradle/tasks/PublishMainSiteTaskSpec.groovy
+++ b/buildSrc/src/test/groovy/website/gradle/tasks/PublishMainSiteTaskSpec.groovy
@@ -29,8 +29,19 @@ class PublishMainSiteTaskSpec extends Specification {
     @TempDir
     File tempDir
 
+    private static String previousSkipRetryBackoff
+
     def setupSpec() {
+        previousSkipRetryBackoff = System.getProperty('website.publish.skipRetryBackoff')
         System.setProperty('website.publish.skipRetryBackoff', 'true')
+    }
+
+    def cleanupSpec() {
+        if (previousSkipRetryBackoff == null) {
+            System.clearProperty('website.publish.skipRetryBackoff')
+        } else {
+            System.setProperty('website.publish.skipRetryBackoff', previousSkipRetryBackoff)
+        }
     }
 
     void 'retryablePushRejection recognizes porcelain non-fast-forward lines'() {
@@ -41,6 +52,13 @@ class PublishMainSiteTaskSpec extends Specification {
                 '!\tHEAD:refs/heads/asf-site-production\t[rejected] (fetch first)')
         !PublishMainSiteTask.retryablePushRejection('error: failed to push some refs')
         !PublishMainSiteTask.retryablePushRejection('')
+    }
+
+    void 'redactAuthenticatedUrls masks credentials in git output'() {
+        expect:
+        PublishMainSiteTask.redactAuthenticatedUrls(
+                'remote: https://oauth2:secret-token@github.com/apache/grails-website.git') ==
+                'remote: https://***@github.com/apache/grails-website.git'
     }
 
     void 'first push succeeds when the destination has not moved'() {

--- a/buildSrc/src/test/groovy/website/gradle/tasks/PublishMainSiteTaskSpec.groovy
+++ b/buildSrc/src/test/groovy/website/gradle/tasks/PublishMainSiteTaskSpec.groovy
@@ -1,0 +1,240 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package website.gradle.tasks
+
+import org.gradle.api.GradleException
+import org.gradle.testfixtures.ProjectBuilder
+
+import spock.lang.Specification
+import spock.lang.TempDir
+
+class PublishMainSiteTaskSpec extends Specification {
+
+    @TempDir
+    File tempDir
+
+    def setupSpec() {
+        System.setProperty('website.publish.skipRetryBackoff', 'true')
+    }
+
+    void 'retryablePushRejection recognizes porcelain non-fast-forward lines'() {
+        expect:
+        PublishMainSiteTask.retryablePushRejection(
+                '!\tHEAD:refs/heads/asf-site-production\t[rejected] (non-fast-forward)')
+        PublishMainSiteTask.retryablePushRejection(
+                '!\tHEAD:refs/heads/asf-site-production\t[rejected] (fetch first)')
+        !PublishMainSiteTask.retryablePushRejection('error: failed to push some refs')
+        !PublishMainSiteTask.retryablePushRejection('')
+    }
+
+    void 'first push succeeds when the destination has not moved'() {
+        given:
+        GitFixture git = new GitFixture(tempDir)
+        git.seedRemote()
+        File publisher = git.clonePublisher('publisher')
+        String clonedTip = git.revParse(publisher)
+        new File(publisher, 'index.html').text = 'site-a'
+        git.commitAll(publisher, 'publish site a')
+        PublishMainSiteTask task = newTask()
+
+        when:
+        task.pushWithRetry(publisher, git.remoteUrl, 'asf-site-production', clonedTip)
+
+        then:
+        git.fileOnRemote('index.html') == 'site-a'
+        git.fileOnRemote('docs/keep.txt') == 'core-docs'
+    }
+
+    void 'disjoint concurrent commit is rebased and both changes are kept'() {
+        given:
+        GitFixture git = new GitFixture(tempDir)
+        git.seedRemote()
+        File publisher = git.clonePublisher('publisher')
+        String clonedTip = git.revParse(publisher)
+        new File(publisher, 'index.html').text = 'site-a'
+        git.commitAll(publisher, 'publish site a')
+
+        File other = git.clonePublisher('other')
+        new File(other, 'docs/keep.txt').text = 'core-docs-updated'
+        git.commitAll(other, 'core docs')
+        git.push(other)
+
+        PublishMainSiteTask task = newTask()
+
+        when:
+        task.pushWithRetry(publisher, git.remoteUrl, 'asf-site-production', clonedTip)
+
+        then:
+        git.fileOnRemote('index.html') == 'site-a'
+        git.fileOnRemote('docs/keep.txt') == 'core-docs-updated'
+    }
+
+    void 'conflicting rebase aborts without replacing the remote winner'() {
+        given:
+        GitFixture git = new GitFixture(tempDir)
+        git.seedRemote()
+        File publisher = git.clonePublisher('publisher')
+        String clonedTip = git.revParse(publisher)
+        new File(publisher, 'index.html').text = 'site-a'
+        git.commitAll(publisher, 'publish site a')
+
+        File other = git.clonePublisher('other')
+        new File(other, 'index.html').text = 'site-b'
+        git.commitAll(other, 'publish site b')
+        git.push(other)
+
+        PublishMainSiteTask task = newTask()
+
+        when:
+        task.pushWithRetry(publisher, git.remoteUrl, 'asf-site-production', clonedTip)
+
+        then:
+        def e = thrown(GradleException)
+        e.message.contains('Rebase failed')
+        git.fileOnRemote('index.html') == 'site-b'
+    }
+
+    void 'unrelated push failures are not retried'() {
+        given:
+        GitFixture git = new GitFixture(tempDir)
+        git.seedRemote()
+        File publisher = git.clonePublisher('publisher')
+        String clonedTip = git.revParse(publisher)
+        new File(publisher, 'index.html').text = 'site-a'
+        git.commitAll(publisher, 'publish site a')
+        PublishMainSiteTask task = newTask()
+
+        when:
+        task.pushWithRetry(publisher, git.remoteUrl + '-missing', 'asf-site-production', clonedTip)
+
+        then:
+        def e = thrown(GradleException)
+        e.message.contains('without a retryable non-fast-forward rejection')
+    }
+
+    void 'rewritten remote history fails closed'() {
+        given:
+        GitFixture git = new GitFixture(tempDir)
+        git.seedRemote()
+        File publisher = git.clonePublisher('publisher')
+        String clonedTip = git.revParse(publisher)
+        new File(publisher, 'index.html').text = 'site-a'
+        git.commitAll(publisher, 'publish site a')
+
+        git.replaceRemoteWithUnrelatedHistory()
+
+        PublishMainSiteTask task = newTask()
+
+        when:
+        task.pushWithRetry(publisher, git.remoteUrl, 'asf-site-production', clonedTip)
+
+        then:
+        def e = thrown(GradleException)
+        e.message.contains('not a descendant') || e.message.contains('without a retryable')
+        git.fileOnRemote('index.html') == 'unrelated'
+    }
+
+    private PublishMainSiteTask newTask() {
+        def project = ProjectBuilder.builder().withProjectDir(new File(tempDir, 'proj')).build()
+        PublishMainSiteTask.register(project)
+        return project.tasks.getByName(PublishMainSiteTask.NAME) as PublishMainSiteTask
+    }
+
+    private static final class GitFixture {
+        final File root
+        final File remote
+        final String remoteUrl
+
+        GitFixture(File tempDir) {
+            root = tempDir
+            remote = new File(tempDir, 'remote.git')
+            remoteUrl = remote.absolutePath
+        }
+
+        void seedRemote() {
+            File seed = new File(root, 'seed')
+            seed.mkdirs()
+            git(seed, 'init', '-b', 'asf-site-production')
+            configureIdentity(seed)
+            new File(seed, 'index.html').text = 'original'
+            new File(seed, 'docs').mkdirs()
+            new File(seed, 'docs/keep.txt').text = 'core-docs'
+            commitAll(seed, 'seed')
+            git(root, 'clone', '--bare', seed.absolutePath, remote.absolutePath)
+        }
+
+        File clonePublisher(String name) {
+            File dir = new File(root, name)
+            git(root, 'clone', '--branch', 'asf-site-production', '--single-branch', remoteUrl, dir.absolutePath)
+            configureIdentity(dir)
+            return dir
+        }
+
+        void commitAll(File repo, String message) {
+            git(repo, 'add', '-A')
+            git(repo, 'commit', '--no-verify', '-m', message)
+        }
+
+        void push(File repo) {
+            git(repo, 'push', 'origin', 'asf-site-production')
+        }
+
+        String revParse(File repo) {
+            git(repo, 'rev-parse', 'HEAD').trim()
+        }
+
+        String fileOnRemote(String path) {
+            File inspect = new File(root, "inspect-${UUID.randomUUID()}")
+            git(root, 'clone', '--branch', 'asf-site-production', '--single-branch', '--depth', '1',
+                    remoteUrl, inspect.absolutePath)
+            return new File(inspect, path).text
+        }
+
+        void replaceRemoteWithUnrelatedHistory() {
+            File other = new File(root, 'unrelated')
+            other.mkdirs()
+            git(other, 'init', '-b', 'asf-site-production')
+            configureIdentity(other)
+            new File(other, 'index.html').text = 'unrelated'
+            commitAll(other, 'orphan')
+            git(other, 'remote', 'add', 'origin', remoteUrl)
+            git(other, 'push', '--force', 'origin', 'HEAD:asf-site-production')
+        }
+
+        private static void configureIdentity(File repo) {
+            git(repo, 'config', 'user.email', 'ci@example.com')
+            git(repo, 'config', 'user.name', 'ci')
+        }
+
+        private static String git(File dir, String... args) {
+            List<String> cmd = ['git', '-c', 'core.hooksPath=']
+            cmd.addAll(args.toList())
+            Process proc = new ProcessBuilder(cmd)
+                    .directory(dir)
+                    .redirectErrorStream(true)
+                    .start()
+            String out = proc.inputStream.text
+            int code = proc.waitFor()
+            if (code != 0) {
+                throw new IllegalStateException("git ${args.join(' ')} failed (${code}): ${out}")
+            }
+            return out
+        }
+    }
+}


### PR DESCRIPTION
## Why not switch this workflow to `deploy-github-pages`

`apache/grails-github-actions` `deploy-github-pages` (asf after [#110](https://github.com/apache/grails-github-actions/pull/110)) **can** publish to `apache/grails-website` `asf-site-production`. Grails Core already does that with `GH_TOKEN: ${{ secrets.GRAILS_GHTOKEN }}`, `TARGET_REPOSITORY: apache/grails-website`, and `DOCUMENTATION_BRANCH: asf-site-production`. The only formal action input is `token`; destination layout is env vars, not a hard-coded `docs/` path. `TARGET_FOLDER` defaults to `.`. Grails Core sets `TARGET_FOLDER: docs` because *its* output belongs under `docs/`.

That is the wrong shape for this site:

- This job must **additively overlay** `build/dist/` onto the **branch root** and leave grails-core's `docs/` tree (and ASF files such as `.asf.yaml`) in place.
- `PURGE_EXISTING` defaults to `true`. Pointing `TARGET_FOLDER` at `.` with purge would `git rm` the destination checkout, including `docs/`.
- Staging is still `git add --verbose "${PUBLISH_PATH}"/*`. Source copy includes dotfiles, but that glob does **not** stage new root `.htaccess` or `.well-known`.
- `GRADLE_PUBLISH_RELEASE` / `LAST_SNAPSHOT_FOLDER` / `latest` is a versioned-docs layout. This site is not a snapshot-or-version docs tree.

[#110](https://github.com/apache/grails-github-actions/pull/110) added a five-attempt porcelain `non-fast-forward` / `fetch first` rebase retry (no force-push). Sequential site-then-docs action runs are **not** inherently racy after that change. This PR copies that retry into `:publishMainSite` instead of adopting the action.

`GITHUB_TOKEN` still cannot write `apache/grails-website`. A PAT (`GRAILS_GHTOKEN`) is required either way.

## What this PR does

- Port the #110 retry into `publishMainSite`: fetch, require the new tip to descend from the cloned tip, rebase the unpublished commit, retry up to 5 times. Rewritten history and rebase conflicts fail closed.
- Redact authenticated URLs from logged git output.
- Set workflow `permissions.contents` to `read` (this job does not push *this* repo).
- Keep `secrets.GRAILS_GHTOKEN`, `GITHUB_SLUG: apache/grails-website`, `GH_BRANCH: asf-site-production`, and intra-repo `concurrency` with `cancel-in-progress: false`.

## Tests

`PublishMainSiteTaskSpec`: first push, disjoint rebase keeps both trees, conflict aborts, unrelated failures are not retried, rewritten history fails closed, credential URLs are redacted.
