### PR TITLE
Stop the home page from highlighting the Blog menu item

### DIFF
--- a/buildSrc/src/main/groovy/website/gradle/tasks/RenderSiteTask.groovy
+++ b/buildSrc/src/main/groovy/website/gradle/tasks/RenderSiteTask.groovy
@@ -418,10 +418,19 @@ abstract class RenderSiteTask extends GrailsWebsiteTask {
         "<meta name='twitter:card' content='$cardType'/>"
     }
 
+    /** Scheme, host and optional port of an absolute menu link, e.g. {@code https://grails.apache.org}. */
+    private static final String MENU_ITEM_ORIGIN = "(?:[a-zA-Z][a-zA-Z0-9+.\\-]*:)?//[^'/]*"
+
+    /**
+     * Marks the menu item whose link points at {@code path} as active. Only an
+     * origin may precede the path in the href, so the path has to match the
+     * whole link path and not merely its tail: otherwise the home page
+     * ("/index.html") would highlight the Blog archive ("/blog/index.html").
+     */
     static String highlightMenu(String html, String path) {
         String normalizedPath = path.startsWith('/') ? path : "/$path"
         html.replaceFirst(
-                "(<li)(><a href='[^']*${Pattern.quote(normalizedPath)}')",
+                "(<li)(><a href='(?:${MENU_ITEM_ORIGIN})?${Pattern.quote(normalizedPath)}')",
                 "\$1 class='active'\$2"
         )
     }

--- a/buildSrc/src/test/groovy/website/gradle/tasks/RenderSiteTaskSpec.groovy
+++ b/buildSrc/src/test/groovy/website/gradle/tasks/RenderSiteTaskSpec.groovy
@@ -45,6 +45,17 @@ class RenderSiteTaskSpec extends Specification {
             """.stripIndent().trim()
     }
 
+    def 'menu highlighting leaves every item unselected on the home page'() {
+        given: 'the shared menu and the home page path'
+            def menu = """
+                <li><a href='https://grails.apache.org/blog/index.html'>Blog</a></li>
+                <li><a href='https://grails.apache.org/casestudies/index.html'>Case Studies</a></li>
+            """.stripIndent().trim()
+
+        expect: 'no menu item is highlighted, because the home page has none'
+            RenderSiteTask.highlightMenu(menu, '/index.html') == menu
+    }
+
     def 'shared partial placeholders resolve for Guide rendering'() {
         when: 'a shared partial is resolved with placeholders for the site URL and Kapa widget script'
             def partial = RenderSiteTask.resolvePartial(


### PR DESCRIPTION
`highlightMenu` matched the menu path as a suffix of the link href, so the home page ("/index.html") selected the first menu item ending in "/index.html" -- the Blog archive ("/blog/index.html").

Only allow an origin (scheme, host and optional port) to precede the path in the href, so the path has to match the whole link path.