### PR TITLE
Add Grails IntelliJ plugin to downloads and documentation

### DIFF
--- a/buildSrc/src/main/groovy/website/model/documentation/DocumentationPage.groovy
+++ b/buildSrc/src/main/groovy/website/model/documentation/DocumentationPage.groovy
@@ -144,7 +144,7 @@ class DocumentationPage {
      *       (Single-page, User Guide, API Reference) for every stable docs
      *       URL since Grails 1.2.0.</li>
      *   <li><strong>Modules</strong> - the GORM / Security / Upgrade / Testing /
-     *       Views / Async / Database / Redis category boxes, in a two-column
+     *       Views / Async / Database / Redis / IDE category boxes, in a two-column
      *       footer.</li>
      * </ul>
      *
@@ -265,7 +265,7 @@ class DocumentationPage {
                         )
                     }
                     div(class: 'column') {
-                        ['Upgrade', 'Testing', 'Views', 'Async', 'Database', 'Redis'].each { title ->
+                        ['Upgrade', 'Testing', 'Views', 'Async', 'Database', 'Redis', 'IDE'].each { title ->
                             mkp.yieldUnescaped(
                                     DocumentationPage.renderCategory(categories.find {
                                         it.title == title

--- a/conf/modules.yml
+++ b/conf/modules.yml
@@ -109,6 +109,11 @@ modules:
     category: Redis
     title: Redis
     url: https://github.com/apache/grails-redis?tab=readme-ov-file#grails-7
+  intellijplugin:
+    categoryImage: '[%url]/images/plugins.svg'
+    category: IDE
+    title: IntelliJ IDEA Plugin
+    url: https://github.com/apache/grails-intellij-plugin?tab=readme-ov-file#apache-grails-intellij-plugin
   buildstatus:
     categoryImage: '[%url]/images/buildstatus.svg'
     category: Build Status

--- a/conf/releases.yml
+++ b/conf/releases.yml
@@ -46,6 +46,11 @@ companionArtifacts:
       mirrorDirectory: grails-publish
       releaseNotesRepo: apache/grails-gradle-publish
       displayName: Grails Publish Gradle Plugin
+    - artifactId: grails-intellij-plugin
+      version: '262.0.1'
+      mirrorDirectory: intellij
+      releaseNotesRepo: apache/grails-intellij-plugin
+      displayName: Grails IntelliJ Plugin
   '8':
     - artifactId: grails-publish
       version: '1.0.0-M2'


### PR DESCRIPTION
## Summary

- List the Apache Grails IntelliJ plugin as a Grails 7 companion artifact on the downloads page (mirror directory `intellij`, artifact `grails-intellij-plugin`), matching quartz / GitHub Actions / grails-publish.
- Add an IDE documentation module that links to the plugin README, and render that category on the documentation page.

This is a draft because the companion version is currently `262.0.1` from gradle.properties on apache/grails-intellij-plugin. Update conf/releases.yml to the voted ASF version before merge.

## Test plan

- [ ] Confirm 262.0.1 (or the final tag) matches the promoted dist at https://downloads.apache.org/grails/intellij/
- [ ] Download page shows IntelliJ source, SHA512, ASC, and release notes under Grails 7 cards
- [ ] Documentation page shows an IDE card with the README link
- [ ] After the first release, bump the companion version if the placeholder is wrong
