### PR TITLE
Register Grails 8 GORM Event Listeners guide

### DIFF
--- a/conf/guides.yml
+++ b/conf/guides.yml
@@ -946,6 +946,38 @@ guides:
             title: Conclusion
           helpWithGrails: 
             title: Help with Grails 
+      '8':
+        sourcePath: guides/gorm-event-listeners/v8
+        publicationDate: '2026-09-11'
+        tags:
+          - 'gorm'
+          - 'gorm-events'
+          - 'event-listeners'
+          - 'domain-events'
+          - 'async'
+          - 'service-layer'
+          - 'persistence-events'
+          - 'unit-tests'
+          - 'integration-tests'
+        sampleRef:
+          repo: 'grails-guides/gorm-event-listeners'
+          branch: 'grails8'
+        toc:
+          gettingStarted:
+            title: Getting Started
+            requirements: What you will need
+            howto: How to complete the guide
+          writingTheApp:
+            title: Writing the Application
+            dataServices: Data Services
+            async: Listening to events from GORM asynchronously
+            sync: Listening to events from GORM synchronously
+          runningTheTests:
+            title: Running the Tests
+          conclusion:
+            title: Conclusion
+          helpWithGrails:
+            title: Help with Grails
 
   - name: 'gorm-graphql-with-react-and-apollo'
     title: 'Building a GORM/GraphQL App with React and Apollo'


### PR DESCRIPTION
PR #545 added the Grails 8 GORM Event Listeners source under `guides/gorm-event-listeners/v8/` but did not add a `versions['8']` entry in `conf/guides.yml`. The site catalogue, category pages, and `renderGuide_*` tasks only include guides listed in that YAML file, so the v8 guide never appeared at https://grails.apache.org/guides/.

This PR registers that existing v8 source with `sampleRef` on `grails-guides/gorm-event-listeners` branch `grails8`.

Checked Sanjana's other recently merged Grails 8 guide PRs: they already have YAML entries. Remaining v8 `sampleRef`s on master already target existing `grails8` branches rather than leftover `grails4` branches.